### PR TITLE
(Feature) Allow PoA contract to handle hard forks

### DIFF
--- a/contracts/PoaNetworkConsensus.sol
+++ b/contracts/PoaNetworkConsensus.sol
@@ -62,12 +62,19 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
         _;
     }
 
-    function PoaNetworkConsensus(address _masterOfCeremony) public {
+    function PoaNetworkConsensus(address _masterOfCeremony, address[] validators, IProxyStorage _proxyStorage) public {
         // TODO: When you deploy this contract, make sure you hardcode items below
         // Make sure you have those addresses defined in spec.json
         require(_masterOfCeremony != address(0));
+        if(address(_proxyStorage) != address(0)) {
+            isMasterOfCeremonyInitialized = true;
+            proxyStorage = IProxyStorage(_proxyStorage);
+        }
         masterOfCeremony = _masterOfCeremony;
         currentValidators = [masterOfCeremony];
+        for (uint256 y = 0; y < validators.length; y++) {
+            currentValidators.push(validators[y]);
+        }
         for (uint256 i = 0; i < currentValidators.length; i++) {
             validatorsState[currentValidators[i]] = ValidatorState({
                 isValidator: true,

--- a/contracts/PoaNetworkConsensus.sol
+++ b/contracts/PoaNetworkConsensus.sol
@@ -62,14 +62,10 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
         _;
     }
 
-    function PoaNetworkConsensus(address _masterOfCeremony, address[] validators, IProxyStorage _proxyStorage) public {
+    function PoaNetworkConsensus(address _masterOfCeremony, address[] validators) public {
         // TODO: When you deploy this contract, make sure you hardcode items below
         // Make sure you have those addresses defined in spec.json
         require(_masterOfCeremony != address(0));
-        if(address(_proxyStorage) != address(0)) {
-            isMasterOfCeremonyInitialized = true;
-            proxyStorage = IProxyStorage(_proxyStorage);
-        }
         masterOfCeremony = _masterOfCeremony;
         currentValidators = [masterOfCeremony];
         for (uint256 y = 0; y < validators.length; y++) {
@@ -136,8 +132,8 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
     }
 
     function setProxyStorage(address _newAddress) public {
-        // Address of Master of Ceremony;
-        require(msg.sender == masterOfCeremony);
+        // any miner can change the address;
+        require(isValidator(msg.sender));
         require(!isMasterOfCeremonyInitialized);
         require(_newAddress != address(0));
         proxyStorage = IProxyStorage(_newAddress);
@@ -160,5 +156,4 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
     function getCurrentValidatorsLength() public view returns(uint256) {
         return currentValidatorsLength;
     }
-
 }

--- a/test/ballots_storage_test.js
+++ b/test/ballots_storage_test.js
@@ -19,7 +19,7 @@ contract('BallotsStorage [all features]', function (accounts) {
   }
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
-    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
+    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
     proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
     ballotsStorageMock = await BallotsStorageMock.new(proxyStorage.address);
     keysManager = await KeysManagerMock.new(proxyStorage.address, poaNetworkConsensus.address, masterOfCeremony);

--- a/test/ballots_storage_test.js
+++ b/test/ballots_storage_test.js
@@ -19,7 +19,7 @@ contract('BallotsStorage [all features]', function (accounts) {
   }
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
-    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony);
+    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
     proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
     ballotsStorageMock = await BallotsStorageMock.new(proxyStorage.address);
     keysManager = await KeysManagerMock.new(proxyStorage.address, poaNetworkConsensus.address, masterOfCeremony);

--- a/test/ballots_storage_test.js
+++ b/test/ballots_storage_test.js
@@ -20,9 +20,9 @@ contract('BallotsStorage [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
     poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
-    proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
+    proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address);
     ballotsStorageMock = await BallotsStorageMock.new(proxyStorage.address);
-    keysManager = await KeysManagerMock.new(proxyStorage.address, poaNetworkConsensus.address, masterOfCeremony);
+    keysManager = await KeysManagerMock.new(proxyStorage.address, poaNetworkConsensus.address, masterOfCeremony, "0x0000000000000000000000000000000000000000");
     await poaNetworkConsensus.setProxyStorage(proxyStorage.address);
     await proxyStorage.initializeAddresses(keysManager.address, votingToChangeKeys, votingToChangeMinThreshold, votingToChangeProxy, ballotsStorageMock.address);
 

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -13,7 +13,7 @@ contract('KeysManager [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
 
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony);
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -13,7 +13,7 @@ contract('KeysManager [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
 
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -14,8 +14,8 @@ contract('KeysManager [all features]', function (accounts) {
 
   beforeEach(async () => {
     poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
-    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
-    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
+    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address);
+    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony, "0x0000000000000000000000000000000000000000");
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     await proxyStorageMock.initializeAddresses(keysManager.address, masterOfCeremony, masterOfCeremony, masterOfCeremony, masterOfCeremony);
   });
@@ -428,6 +428,89 @@ contract('KeysManager [all features]', function (accounts) {
         true,
         false,
         true]
+      )
+    })
+  })
+
+  describe('#migrateFromPreviousKeysManager', async () => {
+    it('can copy initial keys', async () => {
+      await keysManager.initiateKeys(accounts[1]);
+      let newKeysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony, keysManager.address);
+      keysManager.address.should.be.equal(
+        await newKeysManager.previousKeysManager()
+      )
+      let initialKeys = await newKeysManager.initialKeysCount();
+      initialKeys.should.be.bignumber.equal(1);
+      await newKeysManager.migrateFromPreviousKeysManager("0x0000000000000000000000000000000000000000", accounts[1]);
+      new web3.BigNumber(1).should.be.bignumber.equal(
+        await newKeysManager.initialKeys(accounts[1])
+      )
+      await newKeysManager.migrateFromPreviousKeysManager("0x0000000000000000000000000000000000000000", accounts[2]);
+      new web3.BigNumber(0).should.be.bignumber.equal(
+        await newKeysManager.initialKeys(accounts[2])
+      )
+    })
+    it('copies validator keys', async () => {
+      // let masterOfCeremony = accounts[0];
+      let miningKey = accounts[2];
+      let votingKey = accounts[3];
+      let payoutKey = accounts[4];
+      let mining2 = accounts[5];
+      await proxyStorageMock.setVotingContractMock(accounts[2]);
+      await keysManager.addMiningKey(mining2, {from: accounts[2]}).should.be.fulfilled;
+
+      await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
+      await keysManager.createKeys(miningKey, votingKey, payoutKey, {from: accounts[1]}).should.be.fulfilled;
+      const validatorKeyFromOld = await keysManager.validatorKeys(miningKey);
+      validatorKeyFromOld.should.be.deep.equal([
+        votingKey,
+        payoutKey,
+        true,
+        true,
+        true
+      ])
+      let newKeysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony, keysManager.address);
+      // mining #1
+      await newKeysManager.migrateFromPreviousKeysManager(miningKey,"0x0000000000000000000000000000000000000000");
+
+      let initialKeys = await newKeysManager.initialKeysCount();
+      initialKeys.should.be.bignumber.equal(1);
+      const validatorKey = await newKeysManager.validatorKeys(miningKey);
+      validatorKey.should.be.deep.equal([
+        votingKey,
+        payoutKey,
+        true,
+        true,
+        true
+      ])
+
+      miningKey.should.be.equal(
+        await newKeysManager.getMiningKeyByVoting(votingKey)
+      );
+
+      true.should.be.equal(
+        await newKeysManager.isMiningActive(miningKey)
+      )
+      true.should.be.equal(
+        await newKeysManager.isVotingActive(votingKey)
+      )
+      true.should.be.equal(
+        await newKeysManager.isPayoutActive(miningKey)
+      )
+
+      // mining#2
+      await newKeysManager.migrateFromPreviousKeysManager(mining2,"0x0000000000000000000000000000000000000000");
+      const validatorKey2 = await newKeysManager.validatorKeys(mining2);
+      validatorKey2.should.be.deep.equal([
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
+        true,
+        false,
+        false
+      ])
+
+      true.should.be.equal(
+        await newKeysManager.isMiningActive(miningKey)
       )
     })
   })

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -33,8 +33,8 @@ contract('ValidatorMetadata [all features]', function (accounts) {
   miningKey2 = accounts[4];
   beforeEach(async () => { 
     poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
-    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
-    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
+    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address);
+    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony, "0x0000000000000000000000000000000000000000");
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     await proxyStorageMock.initializeAddresses(keysManager.address, masterOfCeremony, masterOfCeremony, masterOfCeremony, ballotsStorage.address);

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -32,7 +32,7 @@ contract('ValidatorMetadata [all features]', function (accounts) {
   miningKey = accounts[1];
   miningKey2 = accounts[4];
   beforeEach(async () => { 
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -32,7 +32,7 @@ contract('ValidatorMetadata [all features]', function (accounts) {
   miningKey = accounts[1];
   miningKey2 = accounts[4];
   beforeEach(async () => { 
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony);
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);

--- a/test/mockContracts/KeysManagerMock.sol
+++ b/test/mockContracts/KeysManagerMock.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.4.18;
 import '../../contracts/KeysManager.sol';
 
 contract KeysManagerMock is KeysManager {
-  function KeysManagerMock(address _proxyStorage, address _poaConsensus, address _masterOfCeremony)
-   KeysManager(_proxyStorage, _poaConsensus, _masterOfCeremony) 
+  function KeysManagerMock(address _proxyStorage, address _poaConsensus, address _masterOfCeremony, address _previousKeysManager)
+   KeysManager(_proxyStorage, _poaConsensus, _masterOfCeremony, _previousKeysManager) 
   {
   }
   function setMasterOfCeremony(address _newAddress) {

--- a/test/mockContracts/PoaNetworkConsensusMock.sol
+++ b/test/mockContracts/PoaNetworkConsensusMock.sol
@@ -1,11 +1,14 @@
 pragma solidity ^0.4.18;
 import '../../contracts/PoaNetworkConsensus.sol';
 import '../../contracts/ProxyStorage.sol';
+import '../../contracts/interfaces/IProxyStorage.sol';
 
 contract PoaNetworkConsensusMock is PoaNetworkConsensus {
     //For testing
     // address public systemAddress = 0xfffffffffffffffffffffffffffffffffffffffe;
-    function PoaNetworkConsensusMock(address _moc) PoaNetworkConsensus(_moc) {}
+    function PoaNetworkConsensusMock(address _moc, address[] validators, IProxyStorage _proxyStorage) 
+        PoaNetworkConsensus(_moc, validators, _proxyStorage) 
+    {}
     function setSystemAddress(address _newAddress) public {
         systemAddress = _newAddress;
     }

--- a/test/mockContracts/PoaNetworkConsensusMock.sol
+++ b/test/mockContracts/PoaNetworkConsensusMock.sol
@@ -6,8 +6,8 @@ import '../../contracts/interfaces/IProxyStorage.sol';
 contract PoaNetworkConsensusMock is PoaNetworkConsensus {
     //For testing
     // address public systemAddress = 0xfffffffffffffffffffffffffffffffffffffffe;
-    function PoaNetworkConsensusMock(address _moc, address[] validators, IProxyStorage _proxyStorage) 
-        PoaNetworkConsensus(_moc, validators, _proxyStorage) 
+    function PoaNetworkConsensusMock(address _moc, address[] validators) 
+        PoaNetworkConsensus(_moc, validators) 
     {}
     function setSystemAddress(address _newAddress) public {
         systemAddress = _newAddress;

--- a/test/mockContracts/ProxyStorageMock.sol
+++ b/test/mockContracts/ProxyStorageMock.sol
@@ -2,8 +2,8 @@ pragma solidity ^0.4.18;
 import '../../contracts/ProxyStorage.sol';
 
 contract ProxyStorageMock is ProxyStorage {
-    function ProxyStorageMock(address _poaConsensus, address _moc)
-    ProxyStorage(_poaConsensus, _moc)
+    function ProxyStorageMock(address _poaConsensus)
+    ProxyStorage(_poaConsensus)
   {
   }
     uint256 public time;
@@ -30,9 +30,5 @@ contract ProxyStorageMock is ProxyStorage {
 
     function setKeysManagerMock(address _newAddress) public {
         keysManager = _newAddress;
-    }
-
-    function setMoc(address _moc) public {
-      masterOfCeremony = _moc;
     }
 }

--- a/test/poa_network_consensus_test.js
+++ b/test/poa_network_consensus_test.js
@@ -12,7 +12,7 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
     let masterOfCeremony = accounts[0];
     beforeEach(async () => {
         poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
-        proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
+        proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensus.address);
         await poaNetworkConsensus.setProxyStorage(proxyStorageMock.address);
         await proxyStorageMock.initializeAddresses(masterOfCeremony, masterOfCeremony, masterOfCeremony, masterOfCeremony, masterOfCeremony);
     });

--- a/test/poa_network_consensus_test.js
+++ b/test/poa_network_consensus_test.js
@@ -11,7 +11,7 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
     let proxyStorageMock;
     let masterOfCeremony = accounts[0];
     beforeEach(async () => {
-        poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony);
+        poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
         proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
         await poaNetworkConsensus.setProxyStorage(proxyStorageMock.address);
         await proxyStorageMock.initializeAddresses(masterOfCeremony, masterOfCeremony, masterOfCeremony, masterOfCeremony, masterOfCeremony);
@@ -30,6 +30,34 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
         it('checks systemAddress', async () => {
             let systemAddress = await poaNetworkConsensus.systemAddress();
             systemAddress.should.be.equal('0xfffffffffffffffffffffffffffffffffffffffe');
+        })
+        it('allows you to set current list of validators', async () => {
+            let validatorsList = [accounts[2], accounts[3], accounts[4]];
+            let poa = await PoaNetworkConsensus.new(masterOfCeremony, validatorsList, "0x0000000000000000000000000000000000000000");
+            let validators = await poa.getValidators();
+            let finalized = await poa.finalized();
+            validators.should.be.deep.equal([
+                masterOfCeremony,
+                ...validatorsList
+            ]);
+
+        })
+        it('allows you to set proxyStorage', async () => {
+            let validatorsList = [accounts[2], accounts[3], accounts[4]];
+            let poa = await PoaNetworkConsensus.new(masterOfCeremony, validatorsList, "0x5ffc014343cd971b7eb70732021e26c35b744cc4");
+            let validators = await poa.getValidators();
+            let finalized = await poa.finalized();
+            validators.should.be.deep.equal([
+                masterOfCeremony,
+                ...validatorsList
+            ]);
+            true.should.be.equal(await poa.isMasterOfCeremonyInitialized());
+            let pendingList = await poa.getPendingList();
+            pendingList.should.be.deep.equal([
+                masterOfCeremony,
+                ...validatorsList
+            ]);
+            new web3.BigNumber(4).should.be.bignumber.equal(await poa.getCurrentValidatorsLength())
         })
     })
 

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -18,7 +18,7 @@ contract('ProxyStorage [all features]', function (accounts) {
   }
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
-    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony);
+    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
     proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
   })
   describe('#contstuctor', async () => {

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -19,15 +19,15 @@ contract('ProxyStorage [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
     poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
-    proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
+    proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address);
   })
   describe('#contstuctor', async () => {
     it('sets MoC and Poa', async () => {
-      masterOfCeremony.should.be.equal(
-        await proxyStorage.masterOfCeremony()
-      );
       poaNetworkConsensus.address.should.be.equal(
         await proxyStorage.getPoaConsensus()
+      );
+      true.should.be.equal(
+        await proxyStorage.isValidator(masterOfCeremony)
       );
     })
   })
@@ -125,6 +125,12 @@ contract('ProxyStorage [all features]', function (accounts) {
       await proxyStorage.setContractAddress(5, accounts[4], {from: votingToChangeProxy}).should.be.fulfilled;
       accounts[4].should.be.equal(
         await proxyStorage.getBallotsStorage()
+      )
+    })
+    it('sets ballotsStorage', async () => {
+      await proxyStorage.setContractAddress(6, accounts[4], {from: votingToChangeProxy}).should.be.fulfilled;
+      accounts[4].should.be.equal(
+        await proxyStorage.getPoaConsensus()
       )
     })
   })

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -18,7 +18,7 @@ contract('ProxyStorage [all features]', function (accounts) {
   }
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
-    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
+    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
     proxyStorage = await ProxyStorageMock.new(poaNetworkConsensus.address, masterOfCeremony);
   })
   describe('#contstuctor', async () => {

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -23,7 +23,7 @@ contract('Voting to change keys [all features]', function (accounts) {
   miningKeyForVotingKey = accounts[1];
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony);
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -24,8 +24,8 @@ contract('Voting to change keys [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
     poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
-    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
-    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
+    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address);
+    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony, "0x0000000000000000000000000000000000000000");
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     voting = await VotingToChangeKeysMock.new(proxyStorageMock.address);

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -23,7 +23,7 @@ contract('Voting to change keys [all features]', function (accounts) {
   miningKeyForVotingKey = accounts[1];
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);

--- a/test/voting_to_change_min_threshold_test.js
+++ b/test/voting_to_change_min_threshold_test.js
@@ -27,7 +27,7 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
   miningKeyForVotingKey = accounts[1];
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony);
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);

--- a/test/voting_to_change_min_threshold_test.js
+++ b/test/voting_to_change_min_threshold_test.js
@@ -28,8 +28,8 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
   miningKeyForVotingKey = accounts[1];
   beforeEach(async () => {
     poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
-    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
-    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
+    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address);
+    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony, "0x0000000000000000000000000000000000000000");
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     voting = await Voting.new(proxyStorageMock.address);

--- a/test/voting_to_change_min_threshold_test.js
+++ b/test/voting_to_change_min_threshold_test.js
@@ -27,7 +27,7 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
   miningKeyForVotingKey = accounts[1];
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -26,8 +26,8 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
   
   beforeEach(async () => {
     poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
-    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
-    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
+    proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address);
+    keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony, "0x0000000000000000000000000000000000000000");
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     voting = await VotingToChangeProxyAddress.new(proxyStorageMock.address);

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -25,7 +25,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
   miningKeyForVotingKey = accounts[1];
   
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony);
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -25,7 +25,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
   miningKeyForVotingKey = accounts[1];
   
   beforeEach(async () => {
-    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, [], "0x0000000000000000000000000000000000000000");
+    poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
     proxyStorageMock = await ProxyStorageMock.new(poaNetworkConsensusMock.address, masterOfCeremony);
     keysManager = await KeysManagerMock.new(proxyStorageMock.address, poaNetworkConsensusMock.address, masterOfCeremony);
     ballotsStorage = await BallotsStorage.new(proxyStorageMock.address);


### PR DESCRIPTION
In order to use multiset feature from parity, we have to be able to
1. Set ProxyStorage via constructor
2. Set Previous Set of Validators 
