### PR TITLE
(Improvement) Split migration method into 2 separate method and event

### DIFF
--- a/contracts/interfaces/IKeysManager.sol
+++ b/contracts/interfaces/IKeysManager.sol
@@ -22,4 +22,6 @@ interface IKeysManager {
     function getMiningKeyHistory(address) public view returns(address);
     function getMiningKeyByVoting(address) public view returns(address);
     function getInitialKey(address) public view returns(uint8);
+    function migrateInitialKey(address) public;
+    function migrateMiningKey(address) public;
 }

--- a/contracts/interfaces/IProxyStorage.sol
+++ b/contracts/interfaces/IProxyStorage.sol
@@ -9,4 +9,5 @@ interface IProxyStorage {
     function getPoaConsensus() public view returns(address);
     function initializeAddresses(address, address, address, address, address) public;
     function setContractAddress(uint256, address) public;
+    function isValidator(address) public view returns(bool);
 }

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -12,9 +12,9 @@ module.exports = async function(deployer, network, accounts) {
   let poaNetworkConsensusAddress = process.env.POA_NETWORK_CONSENSUS_ADDRESS;
   if(network === 'sokol'){
     poaNetworkConsensus = await PoaNetworkConsensus.at(poaNetworkConsensusAddress);
-    await deployer.deploy(ProxyStorage, poaNetworkConsensusAddress, masterOfCeremony);
+    await deployer.deploy(ProxyStorage, poaNetworkConsensusAddress);
     await poaNetworkConsensus.setProxyStorage(ProxyStorage.address);
-    await deployer.deploy(KeysManager, ProxyStorage.address, poaNetworkConsensusAddress, masterOfCeremony);
+    await deployer.deploy(KeysManager, ProxyStorage.address, poaNetworkConsensusAddress, masterOfCeremony, "0x0000000000000000000000000000000000000000");
     await deployer.deploy(BallotsStorage, ProxyStorage.address);
     await deployer.deploy(ValidatorMetadata, ProxyStorage.address);
     await deployer.deploy(VotingToChangeKeys, ProxyStorage.address);
@@ -28,7 +28,7 @@ module.exports = async function(deployer, network, accounts) {
       BallotsStorage.address)
     console.log('Done')
     console.log('ADDRESSES:\n', 
-    `VotingToChangeKeys.address ${VotingToChangeKeys.address} \n
+   `VotingToChangeKeys.address ${VotingToChangeKeys.address} \n
     VotingToChangeMinThreshold.address ${VotingToChangeMinThreshold.address} \n
     VotingToChangeProxyAddress.address ${VotingToChangeProxyAddress.address} \n
     BallotsStorage.address ${BallotsStorage.address} \n


### PR DESCRIPTION
1. Change IF to `require` for error handling
2. Split 1 method into 2 `migrateInitialKey` and `migrateMiningKey` 
3. Add event Migrate