### PR TITLE
(Fix) Swap mining keys copies voting and payout over

### DIFF
--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -200,8 +200,19 @@ contract KeysManager is IKeysManager {
 
     function swapMiningKey(address _key, address _oldMiningKey) public onlyVotingToChangeKeys {
         miningKeyHistory[_key] = _oldMiningKey;
+        Keys storage validator = validatorKeys[_oldMiningKey];
+        require(validator.isMiningActive);
+        validatorKeys[_key] = Keys({
+            votingKey: validator.votingKey,
+            payoutKey: validator.payoutKey,
+            isVotingActive: validator.isVotingActive,
+            isPayoutActive: validator.isPayoutActive,
+            isMiningActive: true
+        });
+        poaNetworkConsensus.addValidator(_key);
+        miningKeyByVoting[validator.votingKey] = _key;
+        MiningKeyChanged(_key, "swapped");
         _removeMiningKey(_oldMiningKey);
-        _addMiningKey(_key);
     }
 
     function swapVotingKey(address _key, address _miningKey) public onlyVotingToChangeKeys {
@@ -237,7 +248,7 @@ contract KeysManager is IKeysManager {
     function _addVotingKey(address _key, address _miningKey) private {
         Keys storage validator = validatorKeys[_miningKey];
         require(validator.isMiningActive && _key != _miningKey);
-        if (validator.isVotingActive) {
+        if (validator.isVotingActive && validator.votingKey != address(0)) {
             _swapVotingKey(_key, _miningKey);
         } else {
             validator.votingKey = _key;

--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -200,19 +200,19 @@ contract KeysManager is IKeysManager {
 
     function swapMiningKey(address _key, address _oldMiningKey) public onlyVotingToChangeKeys {
         miningKeyHistory[_key] = _oldMiningKey;
-        Keys storage validator = validatorKeys[_oldMiningKey];
-        require(validator.isMiningActive);
+        address votingKey = getVotingByMining(_oldMiningKey);
+        require(isMiningActive(_oldMiningKey));
         validatorKeys[_key] = Keys({
-            votingKey: validator.votingKey,
-            payoutKey: validator.payoutKey,
-            isVotingActive: validator.isVotingActive,
-            isPayoutActive: validator.isPayoutActive,
+            votingKey: votingKey,
+            payoutKey: getPayoutByMining(_oldMiningKey),
+            isVotingActive: isVotingActive(votingKey),
+            isPayoutActive: isPayoutActive(_oldMiningKey),
             isMiningActive: true
         });
         poaNetworkConsensus.addValidator(_key);
-        miningKeyByVoting[validator.votingKey] = _key;
-        MiningKeyChanged(_key, "swapped");
         _removeMiningKey(_oldMiningKey);
+        miningKeyByVoting[votingKey] = _key;
+        MiningKeyChanged(_key, "swapped");
     }
 
     function swapVotingKey(address _key, address _miningKey) public onlyVotingToChangeKeys {

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -396,6 +396,33 @@ contract('KeysManager [all features]', function (accounts) {
         false]
       )
     })
+    it.only('should keep voting and payout keys', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.fulfilled;
+      await keysManager.addPayoutKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await keysManager.swapMiningKey(accounts[4], accounts[1]).should.be.fulfilled;
+      const validator = await keysManager.validatorKeys(accounts[1]);
+      validator.should.be.deep.equal(
+        [ '0x0000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000',
+        false,
+        false,
+        false ]
+      )
+      const validatorNew = await keysManager.validatorKeys(accounts[4]);
+      validatorNew.should.be.deep.equal(
+        [ accounts[2],
+        accounts[3],
+        true,
+        true,
+        true]
+      )
+      await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
+      await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
+      const validators = await poaNetworkConsensusMock.getValidators();
+      validators.should.not.contain(accounts[1]);
+      validators.should.contain(accounts[4]);
+    })
   })
 
   describe('#swapVotingKey', async () => {


### PR DESCRIPTION
Fixes #36 
Previously, swapping mining key would not carry over voting and payout keys as it should