### PR TITLE
Fix swap mining keys

### DIFF
--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -129,7 +129,7 @@ contract KeysManager is IKeysManager {
         });
         miningKeyByVoting[_votingKey] = _miningKey;
         initialKeys[msg.sender] = uint8(InitialKeyState.Deactivated);
-        poaNetworkConsensus.addValidator(_miningKey);
+        poaNetworkConsensus.addValidator(_miningKey, true);
         ValidatorInitialized(_miningKey, _votingKey, _payoutKey);
     }
 
@@ -209,8 +209,14 @@ contract KeysManager is IKeysManager {
             isPayoutActive: isPayoutActive(_oldMiningKey),
             isMiningActive: true
         });
-        poaNetworkConsensus.addValidator(_key);
-        _removeMiningKey(_oldMiningKey);
+        poaNetworkConsensus.swapValidatorKey(_key, _oldMiningKey);
+        validatorKeys[_oldMiningKey] = Keys({
+            votingKey: address(0),
+            payoutKey: address(0),
+            isVotingActive: false,
+            isPayoutActive: false,
+            isMiningActive: false
+        });
         miningKeyByVoting[votingKey] = _key;
         MiningKeyChanged(_key, "swapped");
     }
@@ -241,7 +247,7 @@ contract KeysManager is IKeysManager {
             isPayoutActive: false,
             isMiningActive: true
         });
-        poaNetworkConsensus.addValidator(_key);
+        poaNetworkConsensus.addValidator(_key, true);
         MiningKeyChanged(_key, "added");
     }
 
@@ -281,7 +287,7 @@ contract KeysManager is IKeysManager {
             isPayoutActive: false,
             isMiningActive: false
         });
-        poaNetworkConsensus.removeValidator(_key);
+        poaNetworkConsensus.removeValidator(_key, true);
         MiningKeyChanged(_key, "removed");
     }
 

--- a/contracts/PoaNetworkConsensus.sol
+++ b/contracts/PoaNetworkConsensus.sol
@@ -139,19 +139,7 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
         require(isValidator(_oldKey));
         removeValidator(_oldKey, false);
         addValidator(_newKey, false);
-        fireEventInitializeChange(true);
-    }
-
-    function fireEventInitializeChange(bool isPendingList) public {
-        // force update the list if something didnot work
-        if (isPendingList) {
-            require(msg.sender == getKeysManager());
-            finalized = false;
-            InitiateChange(block.blockhash(block.number - 1), pendingList);
-        } else {
-            require(isValidator(msg.sender));
-            InitiateChange(block.blockhash(block.number - 1), currentValidators);
-        }
+        InitiateChange(block.blockhash(block.number - 1), pendingList);
     }
 
     function setProxyStorage(address _newAddress) public {

--- a/contracts/PoaNetworkConsensus.sol
+++ b/contracts/PoaNetworkConsensus.sol
@@ -102,7 +102,7 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
         ChangeFinalized(getValidators());
     }
 
-    function addValidator(address _validator) public onlyKeysManager isNewValidator(_validator) {
+    function addValidator(address _validator, bool _shouldFireEvent) public onlyKeysManager isNewValidator(_validator) {
         require(_validator != address(0));
         validatorsState[_validator] = ValidatorState({
             isValidator: true,
@@ -110,10 +110,12 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
         });
         pendingList.push(_validator);
         finalized = false;
-        InitiateChange(block.blockhash(block.number - 1), pendingList);
+        if (_shouldFireEvent) {
+            InitiateChange(block.blockhash(block.number - 1), pendingList);
+        }
     }
 
-    function removeValidator(address _validator) public onlyKeysManager isNotNewValidator(_validator) {
+    function removeValidator(address _validator, bool _shouldFireEvent) public onlyKeysManager isNotNewValidator(_validator) {
         uint256 removedIndex = validatorsState[_validator].index;
         // Can not remove the last validator.
         uint256 lastIndex = pendingList.length - 1;
@@ -128,7 +130,28 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
         validatorsState[_validator].index = 0;
         validatorsState[_validator].isValidator = false;
         finalized = false;
-        InitiateChange(block.blockhash(block.number - 1), pendingList);
+        if (_shouldFireEvent) {
+            InitiateChange(block.blockhash(block.number - 1), pendingList);
+        }
+    }
+
+    function swapValidatorKey(address _newKey, address _oldKey) public onlyKeysManager {
+        require(isValidator(_oldKey));
+        removeValidator(_oldKey, false);
+        addValidator(_newKey, false);
+        fireEventInitializeChange(true);
+    }
+
+    function fireEventInitializeChange(bool isPendingList) public {
+        // force update the list if something didnot work
+        if (isPendingList) {
+            require(msg.sender == getKeysManager());
+            finalized = false;
+            InitiateChange(block.blockhash(block.number - 1), pendingList);
+        } else {
+            require(isValidator(msg.sender));
+            InitiateChange(block.blockhash(block.number - 1), currentValidators);
+        }
     }
 
     function setProxyStorage(address _newAddress) public {

--- a/contracts/interfaces/IPoaNetworkConsensus.sol
+++ b/contracts/interfaces/IPoaNetworkConsensus.sol
@@ -5,8 +5,9 @@ interface IPoaNetworkConsensus {
     function getValidators() public view returns(address[]);
     function getPendingList() public view returns(address[]);
     function finalizeChange() public;
-    function addValidator(address) public;
-    function removeValidator(address) public;
+    function addValidator(address, bool) public;
+    function removeValidator(address, bool) public;
     function isValidator(address) public view returns(bool);
     function getCurrentValidatorsLength() public view returns(uint256);
+    function swapValidatorKey(address, address) public;
 }

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -11,31 +11,35 @@ module.exports = async function(deployer, network, accounts) {
   let masterOfCeremony = process.env.MASTER_OF_CEREMONY;
   let poaNetworkConsensusAddress = process.env.POA_NETWORK_CONSENSUS_ADDRESS;
   if(network === 'sokol'){
-    poaNetworkConsensus = await PoaNetworkConsensus.at(poaNetworkConsensusAddress);
-    await deployer.deploy(ProxyStorage, poaNetworkConsensusAddress);
-    await poaNetworkConsensus.setProxyStorage(ProxyStorage.address);
-    await deployer.deploy(KeysManager, ProxyStorage.address, poaNetworkConsensusAddress, masterOfCeremony, "0x0000000000000000000000000000000000000000");
-    await deployer.deploy(BallotsStorage, ProxyStorage.address);
-    await deployer.deploy(ValidatorMetadata, ProxyStorage.address);
-    await deployer.deploy(VotingToChangeKeys, ProxyStorage.address);
-    await deployer.deploy(VotingToChangeMinThreshold, ProxyStorage.address);
-    await deployer.deploy(VotingToChangeProxyAddress, ProxyStorage.address);
-    let proxyStorage = await ProxyStorage.deployed();
-    await proxyStorage.initializeAddresses(KeysManager.address,
-      VotingToChangeKeys.address,
-      VotingToChangeMinThreshold.address,
-      VotingToChangeProxyAddress.address,
-      BallotsStorage.address)
-    console.log('Done')
-    console.log('ADDRESSES:\n', 
-   `VotingToChangeKeys.address ${VotingToChangeKeys.address} \n
-    VotingToChangeMinThreshold.address ${VotingToChangeMinThreshold.address} \n
-    VotingToChangeProxyAddress.address ${VotingToChangeProxyAddress.address} \n
-    BallotsStorage.address ${BallotsStorage.address} \n
-    KeysManager.address ${KeysManager.address} \n
-    ValidatorMetadata.address ${ValidatorMetadata.address} \n
-    ProxyStorage.address ${ProxyStorage.address} \n
-    `)
+    try {
+      poaNetworkConsensus = await PoaNetworkConsensus.at(poaNetworkConsensusAddress);
+      await deployer.deploy(ProxyStorage, poaNetworkConsensusAddress);
+      await deployer.deploy(KeysManager, ProxyStorage.address, poaNetworkConsensusAddress, masterOfCeremony, "0x0000000000000000000000000000000000000000");
+      await deployer.deploy(BallotsStorage, ProxyStorage.address);
+      await deployer.deploy(ValidatorMetadata, ProxyStorage.address);
+      await deployer.deploy(VotingToChangeKeys, ProxyStorage.address);
+      await deployer.deploy(VotingToChangeMinThreshold, ProxyStorage.address);
+      await deployer.deploy(VotingToChangeProxyAddress, ProxyStorage.address);
+      let proxyStorage = await ProxyStorage.deployed();
+      await poaNetworkConsensus.setProxyStorage(ProxyStorage.address);
+      await proxyStorage.initializeAddresses(KeysManager.address,
+        VotingToChangeKeys.address,
+        VotingToChangeMinThreshold.address,
+        VotingToChangeProxyAddress.address,
+        BallotsStorage.address)
+      console.log('Done')
+      console.log('ADDRESSES:\n', 
+     `VotingToChangeKeys.address ${VotingToChangeKeys.address} \n
+      VotingToChangeMinThreshold.address ${VotingToChangeMinThreshold.address} \n
+      VotingToChangeProxyAddress.address ${VotingToChangeProxyAddress.address} \n
+      BallotsStorage.address ${BallotsStorage.address} \n
+      KeysManager.address ${KeysManager.address} \n
+      ValidatorMetadata.address ${ValidatorMetadata.address} \n
+      ProxyStorage.address ${ProxyStorage.address} \n
+      `)
+    } catch (error) {
+      console.error(error);
+    }
 
   }
 };

--- a/test/ballots_storage_test.js
+++ b/test/ballots_storage_test.js
@@ -66,7 +66,7 @@ contract('BallotsStorage [all features]', function (accounts) {
   describe('#getTotalNumberOfValidators', async () => {
     it('returns total number of validators', async () => {
       await proxyStorage.setKeysManagerMock(masterOfCeremony);
-      await poaNetworkConsensus.addValidator(accounts[1]);
+      await poaNetworkConsensus.addValidator(accounts[1], true);
       await poaNetworkConsensus.setSystemAddress(masterOfCeremony);
       await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
       const getValidators = await poaNetworkConsensus.getValidators();
@@ -78,11 +78,11 @@ contract('BallotsStorage [all features]', function (accounts) {
     it('returns total number of validators', async () => {
       new web3.BigNumber(1).should.be.bignumber.equal(await ballotsStorageMock.getProxyThreshold())
       await proxyStorage.setKeysManagerMock(masterOfCeremony);
-      await poaNetworkConsensus.addValidator(accounts[1]);
-      await poaNetworkConsensus.addValidator(accounts[2]);
-      await poaNetworkConsensus.addValidator(accounts[3]);
-      await poaNetworkConsensus.addValidator(accounts[4]);
-      await poaNetworkConsensus.addValidator(accounts[5]);
+      await poaNetworkConsensus.addValidator(accounts[1], true);
+      await poaNetworkConsensus.addValidator(accounts[2], true);
+      await poaNetworkConsensus.addValidator(accounts[3], true);
+      await poaNetworkConsensus.addValidator(accounts[4], true);
+      await poaNetworkConsensus.addValidator(accounts[5], true);
       await poaNetworkConsensus.setSystemAddress(accounts[0]);
       await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
       const getValidators = await poaNetworkConsensus.getValidators();

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,6 @@ async function addValidators({
   poaNetworkConsensusMock
 }) {
   arrayOfAddresses = arrayOfAddresses || arrayOfHundredAddresses;
-  console.log(arrayOfAddresses.length)
   await proxyStorageMock.setVotingContractMock(masterOfCeremony);
   for(let validator of arrayOfAddresses){
     await keysManager.addMiningKey(validator).should.be.fulfilled;

--- a/test/poa_network_consensus_test.js
+++ b/test/poa_network_consensus_test.js
@@ -79,8 +79,8 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
         })
 
         it('set currentValidators to pendingList after addValidator call', async () => {
-            await poaNetworkConsensus.addValidator(accounts[1], {from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
-            await poaNetworkConsensus.addValidator(accounts[1]);
+            await poaNetworkConsensus.addValidator(accounts[1], true, {from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+            await poaNetworkConsensus.addValidator(accounts[1], true);
             await poaNetworkConsensus.setSystemAddress(accounts[0]);
             await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
             let currentValidatorsLength = await poaNetworkConsensus.currentValidatorsLength();
@@ -93,7 +93,7 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
                 pendingList.push(pending);
             }
             currentValidators.should.be.deep.equal(pendingList);
-            await poaNetworkConsensus.addValidator(accounts[2]);
+            await poaNetworkConsensus.addValidator(accounts[2], true);
             await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
             currentValidatorsLength = await poaNetworkConsensus.currentValidatorsLength()
             const expected = [masterOfCeremony, accounts[1], accounts[2]];
@@ -114,26 +114,26 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
 
     describe('#addValidator', async () => {
         it('should be called only from keys manager', async () => {
-            await poaNetworkConsensus.addValidator(accounts[1], {from: accounts[2]}).should.be.rejectedWith(ERROR_MSG);
+            await poaNetworkConsensus.addValidator(accounts[1], true, {from: accounts[2]}).should.be.rejectedWith(ERROR_MSG);
             await proxyStorageMock.setKeysManagerMock(accounts[5]);
-            await poaNetworkConsensus.addValidator(accounts[1], {from: accounts[5]}).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true, {from: accounts[5]}).should.be.fulfilled;
         })
 
         it('should not allow to add already existing validator', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.rejectedWith(ERROR_MSG);
         })
 
         it('should not allow 0x0 addresses', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator('0x0').should.be.rejectedWith(ERROR_MSG);
-            await poaNetworkConsensus.addValidator('0x0000000000000000000000000000000000000000').should.be.rejectedWith(ERROR_MSG);
+            await poaNetworkConsensus.addValidator('0x0', true).should.be.rejectedWith(ERROR_MSG);
+            await poaNetworkConsensus.addValidator('0x0000000000000000000000000000000000000000', true).should.be.rejectedWith(ERROR_MSG);
         })
 
         it('should set validatorsState for new validator', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
             let state = await poaNetworkConsensus.validatorsState(accounts[1]);
             let pendingList = await poaNetworkConsensus.getPendingList();
             state[0].should.be.true;
@@ -142,14 +142,14 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
 
         it('should set finalized to false', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
             let finalized = await poaNetworkConsensus.finalized();
             finalized.should.be.false;
         })
 
         it('should emit InitiateChange with blockhash and pendingList as params', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            const {logs} = await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
+            const {logs} = await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
             let currentValidatorsLength = await poaNetworkConsensus.currentValidatorsLength();
             let currentValidators = [];
             for (let i = 0; i < currentValidatorsLength.toNumber(10); i++) {
@@ -165,28 +165,28 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
     describe('#removeValidator', async () => {
         it('should remove validator', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
-            await poaNetworkConsensus.removeValidator(accounts[1]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
+            await poaNetworkConsensus.removeValidator(accounts[1], true).should.be.fulfilled;
         })
 
         it('should be called only from keys manager', async () => {
-            await poaNetworkConsensus.removeValidator(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+            await poaNetworkConsensus.removeValidator(accounts[1],true).should.be.rejectedWith(ERROR_MSG);
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
-            await poaNetworkConsensus.removeValidator(accounts[1]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
+            await poaNetworkConsensus.removeValidator(accounts[1],true).should.be.fulfilled;
         })
 
         it('should only be allowed to remove from existing set of validators', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.removeValidator(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+            await poaNetworkConsensus.removeValidator(accounts[1],true).should.be.rejectedWith(ERROR_MSG);
         })
 
         it('should decrease length of pendingList', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
             await poaNetworkConsensus.setSystemAddress(accounts[0]);
             await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
-            await poaNetworkConsensus.addValidator(accounts[2]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[2], true).should.be.fulfilled;
             await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
             let currentValidatorsLength = await poaNetworkConsensus.currentValidatorsLength();
             let pendingList = [];
@@ -196,7 +196,7 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
             }
             const indexOfRemovedElement = pendingList.indexOf(accounts[1]);
             pendingList.splice(indexOfRemovedElement, 1);
-            const { logs } = await poaNetworkConsensus.removeValidator(accounts[1]).should.be.fulfilled;
+            const { logs } = await poaNetworkConsensus.removeValidator(accounts[1],true).should.be.fulfilled;
             let pendingListFromContract = logs[0].args['newSet'];
             pendingListFromContract.length.should.be.equal(currentValidatorsLength.toNumber(10) - 1);
             pendingList.should.be.deep.equal(pendingListFromContract);
@@ -207,8 +207,8 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
 
         it('should change validatorsState', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
-            await poaNetworkConsensus.removeValidator(accounts[1]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
+            await poaNetworkConsensus.removeValidator(accounts[1],true).should.be.fulfilled;
             const state = await poaNetworkConsensus.validatorsState(accounts[1]);
             state[0].should.be.false;
             state[1].should.be.bignumber.equal(0);
@@ -216,8 +216,8 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
 
         it('should set finalized to false', async () => {
             await proxyStorageMock.setKeysManagerMock(accounts[0]);
-            await poaNetworkConsensus.addValidator(accounts[1]).should.be.fulfilled;
-            await poaNetworkConsensus.removeValidator(accounts[1]).should.be.fulfilled;
+            await poaNetworkConsensus.addValidator(accounts[1], true).should.be.fulfilled;
+            await poaNetworkConsensus.removeValidator(accounts[1],true).should.be.fulfilled;
             const finalized = await poaNetworkConsensus.finalized();
             finalized.should.be.false;
         })

--- a/truffle.js
+++ b/truffle.js
@@ -24,7 +24,7 @@ module.exports = {
     sokol: {
       host: "localhost",
       port: 8545,
-      gas: 4700000,
+      gas: 5700000,
       network_id: "*" // Match any network id
     },
   },


### PR DESCRIPTION
Previously, we had an issue with double emitting of IntializeChange event due to reusing add/remove methods for mining swap.
In this PR, we implement independent method to make a swap in PoA, and add necessary changes to KeysManager