### PR TITLE
(Feature) script to generate multi-line ABIs of contracts

### DIFF
--- a/scripts/getABI.js
+++ b/scripts/getABI.js
@@ -1,0 +1,29 @@
+var fs = require('fs');
+
+function readFiles(dirname, onFileContent, onError) {
+  fs.readdir(dirname, function(err, filenames) {
+    if (err) {
+      onError(err);
+      return;
+    }
+    filenames.forEach(function(filename) {
+      fs.readFile(dirname + filename, 'utf-8', function(err, content) {
+        if (err) {
+          onError(err);
+          return;
+        }
+        onFileContent(filename, content);
+      });
+    });
+  });
+}
+
+let dir = '../build/contracts/';
+readFiles(dir, function(filename, content) {
+	if (filename.includes(".abi.")) return;
+	let abi = JSON.stringify(JSON.parse(content).abi, null, 2);
+	let abiFileName = `${dir}${filename}.abi.json`;
+	fs.writeFileSync(abiFileName, abi);
+}, function(err) {
+  throw err;
+});


### PR DESCRIPTION
Script to generate multi-line ABIs of contracts.
Run: `node getABI.js` from scripts folder after contracts are compiled with truffle. 
It generates multi-line ABIs of contracts to the `build/contracts` folder
![image 2018-01-22 16-58-25](https://user-images.githubusercontent.com/4341812/35224295-98cb5338-ff95-11e7-9670-8368d1ce38d1.png)
