### PR TITLE
(Fix) Default folder trailing slash for getABI.js script

### DIFF
--- a/scripts/getABI.js
+++ b/scripts/getABI.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-const OUTPUT_DIR = process.env.OUTPUT || '../build/abis';
+const OUTPUT_DIR = process.env.OUTPUT || '../build/abis/';
 if (!fs.existsSync(OUTPUT_DIR)) {
   // Do something
   fs.mkdirSync(OUTPUT_DIR);


### PR DESCRIPTION
**Problem**: If no `OUTPUT` env variable, script generates files in `build` folder with name `abisKeysManager.json`...
**Solution**: Add trailing slash for default folder