### PR TITLE
(Feature) deployment-script: save to file contracts' addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ flat
 mochawesome-report
 coverageEnv
 .DS_Store
+contracts.json

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var PoaNetworkConsensus = artifacts.require("./PoaNetworkConsensus.sol");
 var ProxyStorage = artifacts.require("./ProxyStorage.sol");
 var KeysManager = artifacts.require("./KeysManager.sol");
@@ -39,6 +40,21 @@ module.exports = async function(deployer, network, accounts) {
         VotingToChangeProxyAddress.address,
         BallotsStorage.address)
       await poaNetworkConsensus.setProxyStorage(ProxyStorage.address);
+
+      if (!!process.env.SAVE_TO_FILE === true) {
+        let contracts = {
+          "VOTING_TO_CHANGE_KEYS_ADDRESS": VotingToChangeKeys.address,
+          "VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS": VotingToChangeMinThreshold.address,
+          "VOTING_TO_CHANGE_PROXY_ADDRESS": VotingToChangeProxyAddress.address,
+          "BALLOTS_STORAGE_ADDRESS": BallotsStorage.address,
+          "KEYS_MANAGER_ADDRESS": KeysManager.address,
+          "METADATA_ADDRESS": ValidatorMetadata.address,
+          "PROXY_ADDRESS": ProxyStorage.address
+        }
+
+        await saveToFile('./contracts.json', JSON.stringify(contracts, null, 2));
+      }
+
       console.log('Done')
       console.log('ADDRESSES:\n', 
      `VotingToChangeKeys.address ${VotingToChangeKeys.address} \n
@@ -57,5 +73,15 @@ module.exports = async function(deployer, network, accounts) {
   }
 };
 
-// POA_NETWORK_CONSENSUS_ADDRESS=0x8bf38d4764929064f2d4d3a56520a76ab3df415b MASTER_OF_CEREMONY=0xCf260eA317555637C55F70e55dbA8D5ad8414Cb0 OLD_KEYSMANAGER=0xfc90125492e58dbfe80c0bfb6a2a759c4f703ca8 ./node_modules/.bin/truffle migrate --reset --network sokol
-// DEPLOY_POA=true POA_NETWORK_CONSENSUS_ADDRESS=0x8bf38d4764929064f2d4d3a56520a76ab3df415b MASTER_OF_CEREMONY=0xCf260eA317555637C55F70e55dbA8D5ad8414Cb0 OLD_KEYSMANAGER=0xfc90125492e58dbfe80c0bfb6a2a759c4f703ca8 ./node_modules/.bin/truffle migrate --reset --network sokol
+function saveToFile(filename, content) {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(filename, content, (err) => {
+      console.log(err)
+      if (err) reject(err);
+      resolve();
+    });
+  });
+}
+
+// SAVE_TO_FILE=true POA_NETWORK_CONSENSUS_ADDRESS=0x8bf38d4764929064f2d4d3a56520a76ab3df415b MASTER_OF_CEREMONY=0xCf260eA317555637C55F70e55dbA8D5ad8414Cb0 OLD_KEYSMANAGER=0xfc90125492e58dbfe80c0bfb6a2a759c4f703ca8 ./node_modules/.bin/truffle migrate --reset --network sokol
+// SAVE_TO_FILE=true DEPLOY_POA=true POA_NETWORK_CONSENSUS_ADDRESS=0x8bf38d4764929064f2d4d3a56520a76ab3df415b MASTER_OF_CEREMONY=0xCf260eA317555637C55F70e55dbA8D5ad8414Cb0 OLD_KEYSMANAGER=0xfc90125492e58dbfe80c0bfb6a2a759c4f703ca8 ./node_modules/.bin/truffle migrate --reset --network sokol

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -22,12 +22,13 @@ module.exports = async function(deployer, network, accounts) {
     }
     poaNetworkConsensus = await deployer.deploy(PoaNetworkConsensus, masterOfCeremony, validators);
     console.log(PoaNetworkConsensus.address)
+    poaNetworkConsensusAddress = PoaNetworkConsensus.address
   }
   if(network === 'sokol'){
     try {
       poaNetworkConsensus = poaNetworkConsensus || await PoaNetworkConsensus.at(poaNetworkConsensusAddress);
-      await deployer.deploy(ProxyStorage, PoaNetworkConsensus.address);
-      await deployer.deploy(KeysManager, ProxyStorage.address, PoaNetworkConsensus.address, masterOfCeremony, previousKeysManager);
+      await deployer.deploy(ProxyStorage, poaNetworkConsensusAddress);
+      await deployer.deploy(KeysManager, ProxyStorage.address, poaNetworkConsensusAddress, masterOfCeremony, previousKeysManager);
       await deployer.deploy(BallotsStorage, ProxyStorage.address);
       await deployer.deploy(ValidatorMetadata, ProxyStorage.address);
       await deployer.deploy(VotingToChangeKeys, ProxyStorage.address);


### PR DESCRIPTION
Adds ability to save secondary contracts addresses to the `.json` file from test deployment script with `SAVE_TO_FILE=true` env variable. It is useful for quick POA setup deployment I'm working under.