### PR TITLE
(Fix) README text about PoaNetworkConsensus bytecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@
 - Install solidity-flattener `pip3.5 install solidity-flattener`
 - Install npm dependencies `npm i`
 - Generate flat sources of contracts with the script `./make_flat.sh`
-- We need the byte code of `PoaNetworkConsensus_flat` contract to add it to [`spec.json`](https://github.com/poanetwork/poa-chain-spec/blob/core/spec.json) of the network. <br />
-Go to [Remix](http://remix.ethereum.org/#version=soljson-v0.4.18+commit.9cf6e910.js).<br />
-Copy `./flat/PoaNetworkConsensus_flat.sol` source to the input field and press `Start to compile`. <br />
-Choose `PoaNetworkConsensus` contract in the listbox and press "Details". Copy `BYTECODE` of the compiled source for `spec.json`.
+- We need a bytecode of `PoaNetworkConsensus` contract to add it to [`spec.json`](https://github.com/poanetwork/poa-chain-spec/blob/core/spec.json) of the network. <br />
+Go to `scripts` directory and run `poa-bytecode.js`: <br />
+```bash
+cd scripts
+npm i
+MASTER_OF_CEREMONY=0x0039F22efB07A647557C7C5d17854CFD6D489eF3 node poa-bytecode.js
+```
+It will show the bytecode of `PoaNetworkConsensus` contract. Copy the bytecode and paste it into `spec.json`.
 
 ### Add Contracts to Parity UI.
 

--- a/scripts/poa-bytecode.js
+++ b/scripts/poa-bytecode.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const solc = require('solc');
+const Web3 = require('web3');
+const web3 = new Web3(new Web3.providers.HttpProvider("https://core.poa.network"));
+
+main();
+
+async function main() {
+	console.log('PoaNetworkConsensus compilation...');
+	const compiled = solc.compile({
+		sources: {
+			'': fs.readFileSync('../contracts/PoaNetworkConsensus.sol').toString()
+		}
+	}, 1, function (path) {
+		return {contents: fs.readFileSync('../contracts/' + path).toString()}
+	});
+	const abi = JSON.parse(compiled.contracts[':PoaNetworkConsensus'].interface);
+	let bytecode = compiled.contracts[':PoaNetworkConsensus'].bytecode;
+	
+	const contract = new web3.eth.Contract(abi);
+	const deploy = await contract.deploy({data: '0x' + bytecode, arguments: [process.env.MASTER_OF_CEREMONY, []]});
+	bytecode = await deploy.encodeABI();
+	
+	console.log('PoaNetworkConsensus bytecode:');
+	console.log('');
+	console.log(bytecode);
+}
+
+// MASTER_OF_CEREMONY=0x0039F22efB07A647557C7C5d17854CFD6D489eF3 node poa-bytecode.js


### PR DESCRIPTION
- (Mandatory) Description
There is a wrong manual in `README` about how to get a bytecode of `PoaNetworkConsensus` contract. It doesn't take into account that the bytecode must contain constructor parameters. I have corrected the `README` and have made a small script to generate the bytecode of `PoaNetworkConsensus`.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Fix)