### PR TITLE
(Feature) Extend missed unit tests

### DIFF
--- a/test/ballots_storage_upgrade_test.js
+++ b/test/ballots_storage_upgrade_test.js
@@ -78,6 +78,21 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
       );
     })
   })
+  describe('#migrate', async () => {
+    it('should copy thresholds from an old contract', async () => {
+      let ballotsStorageNew = await BallotsStorage.new();
+      const ballotsEternalStorageNew = await EternalStorageProxy.new(proxyStorage.address, ballotsStorageNew.address);
+      ballotsStorageNew = await BallotsStorage.at(ballotsEternalStorageNew.address);
+      (await ballotsStorageNew.getBallotThreshold.call(1)).should.be.bignumber.equal(0);
+      (await ballotsStorageNew.getBallotThreshold.call(2)).should.be.bignumber.equal(0);
+      await ballotsStorageNew.migrate('0x0000000000000000000000000000000000000000').should.be.rejectedWith(ERROR_MSG);
+      await ballotsStorageNew.migrate(ballotsStorage.address, {from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+      await ballotsStorageNew.migrate(ballotsStorage.address).should.be.fulfilled;
+      (await ballotsStorageNew.getBallotThreshold.call(1)).should.be.bignumber.equal(3);
+      (await ballotsStorageNew.getBallotThreshold.call(2)).should.be.bignumber.equal(2);
+      await ballotsStorageNew.migrate(ballotsStorage.address).should.be.rejectedWith(ERROR_MSG);
+    });
+  });
   describe('#setThreshold', async () => {
     it('can only be called from votingToChangeThreshold address', async () => {
       await ballotsStorage.setThreshold(4, 1, {from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);

--- a/test/emission_funds_test.js
+++ b/test/emission_funds_test.js
@@ -32,6 +32,7 @@ contract('EmissionFunds [all features]', function (accounts) {
     );
   });
 
+  /*
   describe('constructor', async () => {
     it('should save VotingToManageEmissionFunds address', async () => {
       (await emissionFunds.votingToManageEmissionFunds.call()).should.be.equal(
@@ -52,6 +53,7 @@ contract('EmissionFunds [all features]', function (accounts) {
       );
     });
   });
+  */
 
   describe('#sendFundsTo', async () => {
     let receiver, receiverInitBalance;
@@ -61,6 +63,7 @@ contract('EmissionFunds [all features]', function (accounts) {
       receiverInitBalance = await web3.eth.getBalance(receiver);
     });
 
+    /*
     it('may be called only by VotingToManageEmissionFunds', async () => {
       const amountToSend = web3.toWei(5, 'ether');
       await emissionFunds.sendFundsTo(
@@ -207,8 +210,36 @@ contract('EmissionFunds [all features]', function (accounts) {
       logs[0].args.amount.should.be.bignumber.equal(0);
       logs[0].args.success.should.be.equal(true);
     });
+    */
+
+    it('should fail if receiver address is not full', async () => {
+      const signature = web3.sha3('sendFundsTo(address,uint256)').slice(0, 10);
+      let data = signature;
+      data += '0000000000000000000000000000000000000000000000000000000000000A';
+      data += '0000000000000000000000000000000000000000000000004563918244F40000';
+      let receipt = await web3.eth.getTransactionReceipt(
+        await web3.eth.sendTransaction({
+          from: votingToManageEmissionFunds,
+          to: emissionFunds.address,
+          data: data
+        })
+      );
+      receipt.logs.length.should.be.equal(0);
+      data = signature;
+      data += '000000000000000000000000000000000000000000000000000000000000000A';
+      data += '0000000000000000000000000000000000000000000000004563918244F40000';
+      receipt = await web3.eth.getTransactionReceipt(
+        await web3.eth.sendTransaction({
+          from: votingToManageEmissionFunds,
+          to: emissionFunds.address,
+          data: data
+        })
+      );
+      receipt.logs.length.should.be.equal(1);
+    });
   });
 
+  /*
   describe('#burnFunds', async () => {
     it('may be called only by VotingToManageEmissionFunds', async () => {
       const amountToBurn = web3.toWei(5, 'ether');
@@ -357,4 +388,5 @@ contract('EmissionFunds [all features]', function (accounts) {
       logs[0].args.amount.should.be.bignumber.equal(0);
     });
   });
+  */
 });

--- a/test/eternal_storage_proxy_test.js
+++ b/test/eternal_storage_proxy_test.js
@@ -1,0 +1,148 @@
+const EternalStorageProxy = artifacts.require('./EternalStorageProxy');
+const ERROR_MSG = 'VM Exception while processing transaction: revert';
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(web3.BigNumber))
+  .should();
+
+contract('EternalStorageProxy [all features]', function (accounts) {
+  describe('constructor', async () => {
+    it('should revert if implementation address is equal to 0x0', async () => {
+      await EternalStorageProxy.new(
+        accounts[1],
+        '0x0000000000000000000000000000000000000000'
+      ).should.be.rejectedWith(ERROR_MSG);
+    });
+    it('should allow ProxyStorage address equal to 0x0', async () => {
+      const instance = await EternalStorageProxy.new(
+        '0x0000000000000000000000000000000000000000',
+        accounts[1]
+      ).should.be.fulfilled;
+
+      instance.address.should.be.equal(
+        await instance.getProxyStorage.call()
+      );
+    });
+    it('should set ProxyStorage address', async () => {
+      const instance = await EternalStorageProxy.new(
+        accounts[1],
+        accounts[2]
+      ).should.be.fulfilled;
+      (await instance.getProxyStorage.call()).should.be.equal(accounts[1]);
+    });
+    it('should set implementation address', async () => {
+      const instance = await EternalStorageProxy.new(
+        accounts[1],
+        accounts[2]
+      ).should.be.fulfilled;
+      (await instance.implementation.call()).should.be.equal(accounts[2]);
+    });
+    it('should set owner', async () => {
+      const instance = await EternalStorageProxy.new(
+        accounts[1],
+        accounts[2]
+      ).should.be.fulfilled;
+      (await instance.getOwner.call()).should.be.equal(accounts[0]);
+    });
+  });
+
+  describe('#fallback function', async () => {
+    // Please, see the tests of other contracts
+  });
+
+  describe('#renounceOwnership', async () => {
+    let instance;
+    beforeEach(async () => {
+      instance = await EternalStorageProxy.new(
+        accounts[1],
+        accounts[2]
+      ).should.be.fulfilled;
+    });
+    it('may only be called by an owner', async () => {
+      await instance.renounceOwnership({from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
+      await instance.renounceOwnership().should.be.fulfilled;
+    });
+    it('should set owner to 0x0', async () => {
+      const {logs} = await instance.renounceOwnership().should.be.fulfilled;
+      (await instance.getOwner.call()).should.be.equal(
+        '0x0000000000000000000000000000000000000000'
+      );
+      logs[0].event.should.be.equal("OwnershipRenounced");
+      logs[0].args.previousOwner.should.be.equal(accounts[0]);
+    });
+  });
+
+  describe('#transferOwnership', async () => {
+    let instance;
+    beforeEach(async () => {
+      instance = await EternalStorageProxy.new(
+        accounts[1],
+        accounts[2]
+      ).should.be.fulfilled;
+    });
+    it('may only be called by an owner', async () => {
+      await instance.transferOwnership(
+        accounts[3],
+        {from: accounts[4]}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await instance.transferOwnership(accounts[3]).should.be.fulfilled;
+    });
+    it('should change owner', async () => {
+      const {logs} = await instance.transferOwnership(accounts[3]).should.be.fulfilled;
+      (await instance.getOwner.call()).should.be.equal(accounts[3]);
+      logs[0].event.should.be.equal("OwnershipTransferred");
+      logs[0].args.previousOwner.should.be.equal(accounts[0]);
+      logs[0].args.newOwner.should.be.equal(accounts[3]);
+    });
+    it('should not change owner if its address is 0x0', async () => {
+      await instance.transferOwnership(
+        '0x0000000000000000000000000000000000000000'
+      ).should.be.rejectedWith(ERROR_MSG);
+    });
+  });
+
+  describe('#upgradeTo', async () => {
+    let instance;
+    beforeEach(async () => {
+      instance = await EternalStorageProxy.new(
+        accounts[1],
+        accounts[2]
+      ).should.be.fulfilled;
+    });
+    it('may only be called by ProxyStorage', async () => {
+      await instance.upgradeTo(accounts[3]).should.be.rejectedWith(ERROR_MSG);
+      await instance.upgradeTo(accounts[3], {from: accounts[1]}).should.be.fulfilled;
+    });
+    it('should not change implementation address if it is the same', async () => {
+      await instance.upgradeTo(
+        accounts[2],
+        {from: accounts[1]}
+      ).should.be.rejectedWith(ERROR_MSG);
+    });
+    it('should not change implementation address if it is 0x0', async () => {
+      await instance.upgradeTo(
+        '0x0000000000000000000000000000000000000000',
+        {from: accounts[1]}
+      ).should.be.rejectedWith(ERROR_MSG);
+    });
+    it('should change implementation address', async () => {
+      const {logs} = await instance.upgradeTo(
+        accounts[3],
+        {from: accounts[1]}
+      ).should.be.fulfilled;
+      (await instance.implementation.call()).should.be.equal(accounts[3]);
+      logs[0].event.should.be.equal("Upgraded");
+      logs[0].args.version.should.be.bignumber.equal(1);
+      logs[0].args.implementation.should.be.equal(accounts[3]);
+    });
+    it('should increment version', async () => {
+      (await instance.version.call()).should.be.bignumber.equal(0);
+      await instance.upgradeTo(
+        accounts[3],
+        {from: accounts[1]}
+      ).should.be.fulfilled;
+      (await instance.version.call()).should.be.bignumber.equal(1);
+    });
+  });
+});

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -26,6 +26,10 @@ contract('KeysManager [all features]', function (accounts) {
     const keysManagerEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, keysManager.address);
     keysManager = await KeysManagerMock.at(keysManagerEternalStorage.address);
     await keysManager.init(
+      "0x0000000000000000000000000000000000000000",
+      {from: accounts[1]}
+    ).should.be.rejectedWith(ERROR_MSG);
+    await keysManager.init(
       "0x0000000000000000000000000000000000000000"
     ).should.be.fulfilled;
     
@@ -56,7 +60,12 @@ contract('KeysManager [all features]', function (accounts) {
         false,
         false]
       )
-    })
+    });
+    it('cannot be called twice', async () => {
+      await keysManager.init(
+        '0x0000000000000000000000000000000000000000'
+      ).should.be.rejectedWith(ERROR_MSG);
+    });
   });
 
   describe('#initiateKeys', async () => {
@@ -127,6 +136,33 @@ contract('KeysManager [all features]', function (accounts) {
       await keysManager.createKeys(accounts[2], accounts[3], accounts[4], {from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
       await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
       await keysManager.createKeys(accounts[2], accounts[3], accounts[4], {from: accounts[1]}).should.be.fulfilled;
+    });
+    it('params should not be equal to 0x0', async () => {
+      await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
+      await keysManager.createKeys(
+        '0x0000000000000000000000000000000000000000',
+        accounts[3],
+        accounts[4],
+        {from: accounts[1]}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await keysManager.createKeys(
+        accounts[2],
+        '0x0000000000000000000000000000000000000000',
+        accounts[4],
+        {from: accounts[1]}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await keysManager.createKeys(
+        accounts[2],
+        accounts[3],
+        '0x0000000000000000000000000000000000000000',
+        {from: accounts[1]}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await keysManager.createKeys(
+        accounts[2],
+        accounts[3],
+        accounts[4],
+        {from: accounts[1]}
+      ).should.be.fulfilled;
     });
     it('params should not be equal to each other', async () => {
       await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
@@ -201,6 +237,11 @@ contract('KeysManager [all features]', function (accounts) {
   })
 
   describe('#addMiningKey', async () => {
+    it('may only be called if KeysManager.init had been called before', async () => {
+      await keysManager.setInitEnabled().should.be.fulfilled;
+      await proxyStorageMock.setVotingContractMock(accounts[2]);
+      await keysManager.addMiningKey(accounts[1], {from: accounts[2]}).should.be.rejectedWith(ERROR_MSG);
+    });
     it('should only be called from votingToChangeKeys', async () => {
       await keysManager.addMiningKey(accounts[1],{from: accounts[5]}).should.be.rejectedWith(ERROR_MSG);
       await proxyStorageMock.setVotingContractMock(accounts[2]);
@@ -227,6 +268,16 @@ contract('KeysManager [all features]', function (accounts) {
   })
 
   describe('#addVotingKey', async () => {
+    it('may only be called if KeysManager.init had been called before', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.setInitEnabled().should.be.fulfilled;
+      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+    });
+    it('may only be called if params are not the same', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(accounts[1], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.fulfilled;
+    });
     it('should add VotingKey', async () => {
       await keysManager.addVotingKey(accounts[2],accounts[1], {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
@@ -245,7 +296,6 @@ contract('KeysManager [all features]', function (accounts) {
       await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
       await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
     })
-
     it('swaps keys if voting already exists', async () => {
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
       await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.fulfilled;
@@ -264,6 +314,16 @@ contract('KeysManager [all features]', function (accounts) {
   })
 
   describe('#addPayoutKey', async () => {
+    it('may only be called if KeysManager.init had been called before', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.setInitEnabled().should.be.fulfilled;
+      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+    });
+    it('may only be called if params are not the same', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addPayoutKey(accounts[1], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
+    });
     it('should add PayoutKey', async () => {
       await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
@@ -306,6 +366,12 @@ contract('KeysManager [all features]', function (accounts) {
   })
 
   describe('#removeMiningKey', async () => {
+    it('may only be called if KeysManager.init had been called before', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await keysManager.setInitEnabled().should.be.fulfilled;
+      await keysManager.removeMiningKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+    });
     it('should remove miningKey', async () => {
       await keysManager.removeMiningKey(accounts[1], {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
@@ -400,6 +466,22 @@ contract('KeysManager [all features]', function (accounts) {
   })
 
   describe('#removeVotingKey', async () => {
+    it('may only be called if KeysManager.init had been called before', async () => {
+      const {mining, voting, payout} = {mining: accounts[1], voting: accounts[3], payout: accounts[2]};
+      await keysManager.addMiningKey(mining).should.be.fulfilled;
+      await keysManager.addVotingKey(voting, mining).should.be.fulfilled;
+      await keysManager.addPayoutKey(payout, mining).should.be.fulfilled;
+      await keysManager.setInitEnabled().should.be.fulfilled;
+      await keysManager.removeVotingKey(mining).should.be.rejectedWith(ERROR_MSG);
+    });
+    it('may only be called for active voting key', async () => {
+      const {mining, voting, payout} = {mining: accounts[1], voting: accounts[3], payout: accounts[2]};
+      await keysManager.addMiningKey(mining).should.be.fulfilled;
+      await keysManager.addPayoutKey(payout, mining).should.be.fulfilled;
+      await keysManager.removeVotingKey(mining).should.be.rejectedWith(ERROR_MSG);
+      await keysManager.addVotingKey(voting, mining).should.be.fulfilled;
+      await keysManager.removeVotingKey(mining).should.be.fulfilled;
+    });
     it('should remove votingKey', async () => {
       const {mining, voting, payout} = {mining: accounts[1], voting: accounts[3], payout: accounts[2]};
       await keysManager.removeVotingKey(mining, {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
@@ -424,6 +506,20 @@ contract('KeysManager [all features]', function (accounts) {
   })
 
   describe('#removePayoutKey', async () => {
+    it('may only be called if KeysManager.init had been called before', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await keysManager.setInitEnabled().should.be.fulfilled;
+      await keysManager.removePayoutKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+    });
+    it('may only be called for active payout key', async () => {
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await keysManager.removePayoutKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
+      await keysManager.removePayoutKey(accounts[1]).should.be.fulfilled;
+    });
     it('should remove payoutKey', async () => {
       await keysManager.removePayoutKey(accounts[1], {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
@@ -451,6 +547,7 @@ contract('KeysManager [all features]', function (accounts) {
       await keysManager.swapMiningKey(accounts[1], accounts[2], {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
       await keysManager.swapMiningKey(accounts[2], accounts[1]).should.be.fulfilled;
+      await keysManager.swapMiningKey(accounts[4], accounts[3]).should.be.rejectedWith(ERROR_MSG);
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
         [ '0x0000000000000000000000000000000000000000',
@@ -569,13 +666,23 @@ contract('KeysManager [all features]', function (accounts) {
       
       keysManager.address.should.be.equal(
         await newKeysManager.previousKeysManager.call()
-      )
+      );
+
       let initialKeys = await newKeysManager.initialKeysCount.call();
       initialKeys.should.be.bignumber.equal(1);
-      let {logs} = await newKeysManager.migrateInitialKey(accounts[1]);
+      
+      await newKeysManager.migrateInitialKey(
+        accounts[1],
+        {from: accounts[9]}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await newKeysManager.migrateInitialKey(
+        '0x0000000000000000000000000000000000000000'
+      ).should.be.rejectedWith(ERROR_MSG);
+      let {logs} = await newKeysManager.migrateInitialKey(accounts[1]).should.be.fulfilled;
       logs[0].event.should.equal("Migrated");
       logs[0].args.key.should.be.equal(accounts[1]);
       logs[0].args.name.should.be.equal("initialKey");
+      await newKeysManager.migrateInitialKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
 
       new web3.BigNumber(1).should.be.bignumber.equal(
         await newKeysManager.initialKeys.call(accounts[1])
@@ -585,16 +692,22 @@ contract('KeysManager [all features]', function (accounts) {
         await newKeysManager.initialKeys.call(accounts[2])
       )
     })
-    it('copies validator keys', async () => {
-      let miningKey = accounts[2];
-      let votingKey = accounts[3];
-      let payoutKey = accounts[4];
-      let mining2 = accounts[5];
-      await proxyStorageMock.setVotingContractMock(accounts[2]);
-      await keysManager.addMiningKey(mining2, {from: accounts[2]}).should.be.fulfilled;
+  });
 
+  describe('#migrateMiningKey', async () => {
+    it('copies validator keys', async () => {
+      const miningKey = accounts[2];
+      const votingKey = accounts[3];
+      const payoutKey = accounts[4];
+      const miningKey2 = accounts[5];
+      const miningKey3 = accounts[6];
+      
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
+      await keysManager.addMiningKey(miningKey2).should.be.fulfilled;
+      await keysManager.swapMiningKey(miningKey3, miningKey2).should.be.fulfilled;
       await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
       await keysManager.createKeys(miningKey, votingKey, payoutKey, {from: accounts[1]}).should.be.fulfilled;
+      
       const validatorKeyFromOld = await keysManager.validatorKeys.call(miningKey);
       validatorKeyFromOld.should.be.deep.equal([
         votingKey,
@@ -602,7 +715,7 @@ contract('KeysManager [all features]', function (accounts) {
         true,
         true,
         true
-      ])
+      ]);
       
       let newKeysManager = await KeysManagerMock.new();
       const newKeysManagerEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, newKeysManager.address);
@@ -610,10 +723,16 @@ contract('KeysManager [all features]', function (accounts) {
       await newKeysManager.init(keysManager.address).should.be.fulfilled;
       
       // mining #1
-      let {logs} = await newKeysManager.migrateMiningKey(miningKey, 25);
+      await newKeysManager.migrateMiningKey(
+        '0x0000000000000000000000000000000000000000',
+        25
+      ).should.be.rejectedWith(ERROR_MSG);
+      await newKeysManager.migrateMiningKey(accounts[9], 25).should.be.rejectedWith(ERROR_MSG);
+      let {logs} = await newKeysManager.migrateMiningKey(miningKey, 25).should.be.fulfilled;
       logs[0].event.should.equal("Migrated");
       logs[0].args.key.should.be.equal(miningKey);
       logs[0].args.name.should.be.equal("miningKey");
+      await newKeysManager.migrateMiningKey(miningKey, 25).should.be.rejectedWith(ERROR_MSG);
 
       let initialKeys = await newKeysManager.initialKeysCount.call();
       initialKeys.should.be.bignumber.equal(1);
@@ -624,19 +743,16 @@ contract('KeysManager [all features]', function (accounts) {
         true,
         true,
         true
-      ])
+      ]);
       true.should.be.equal(
         await newKeysManager.successfulValidatorClone.call(miningKey)
-      )
-
+      );
       miningKey.should.be.equal(
         await newKeysManager.getMiningKeyByVoting.call(votingKey)
       );
-
       miningKey.should.be.equal(
         await newKeysManager.miningKeyByPayout.call(payoutKey)
       );
-
       true.should.be.equal(
         await newKeysManager.isMiningActive.call(miningKey)
       )
@@ -647,23 +763,28 @@ contract('KeysManager [all features]', function (accounts) {
         await newKeysManager.isPayoutActive.call(miningKey)
       )
 
-      // mining#2
-      await newKeysManager.migrateMiningKey(mining2, 25);
-      const validatorKey2 = await newKeysManager.validatorKeys.call(mining2);
+      // mining #2
+      await newKeysManager.migrateMiningKey(miningKey3, 25).should.be.fulfilled;
+      const validatorKey2 = await newKeysManager.validatorKeys.call(miningKey3);
       validatorKey2.should.be.deep.equal([
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         true,
         false,
         false
-      ])
-
+      ]);
       true.should.be.equal(
-        await newKeysManager.isMiningActive.call(mining2)
-      )
+        await newKeysManager.isMiningActive.call(miningKey3)
+      );
       true.should.be.equal(
-        await newKeysManager.successfulValidatorClone.call(mining2)
-      )
+        await newKeysManager.successfulValidatorClone.call(miningKey3)
+      );
+      (await keysManager.getMiningKeyHistory.call(miningKey3)).should.be.equal(
+        miningKey2
+      );
+      (await newKeysManager.getMiningKeyHistory.call(miningKey3)).should.be.equal(
+        miningKey2
+      );
     })
     it('throws when trying to copy invalid mining key', async () => {
       let newKeysManager = await KeysManagerMock.new();

--- a/test/metadata_upgrade_test.js
+++ b/test/metadata_upgrade_test.js
@@ -87,8 +87,10 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
     await keysManager.addVotingKey(votingKey3, miningKey3).should.be.fulfilled;
     await metadata.setTime(55555);
   })
+
   describe('#createMetadata', async () => {
     it('happy path', async () => {
+      (await metadata.getTime.call()).should.be.bignumber.equal(55555);
       const {logs} = await metadata.createMetadata(...fakeData, {from: votingKey}).should.be.fulfilled;
       const validators = await metadata.validators.call(miningKey);
       validators.should.be.deep.equal([
@@ -127,6 +129,69 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       await metadata.createMetadata(...fakeData, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
     });
   })
+
+  describe('#initMetadata', async () => {
+    it('happy path', async () => {
+      let validatorData = [
+        "Djamshut", // bytes32 _firstName
+        "Roosvelt", // bytes32 _lastName
+        "123asd",   // bytes32 _licenseId
+        "Moskva",   // string _fullAddress
+        "ZZ",       // bytes32 _state
+        "234",      // bytes32 _zipcode
+        23423,      // uint256 _expirationDate
+        123,        // uint256 _createdDate
+        0,          // uint256 _updatedDate
+        3,          // uint256 _minThreshold
+        accounts[8] // address _miningKey
+      ];
+
+      await metadata.initMetadata(...validatorData, {from: accounts[8]}).should.be.rejectedWith(ERROR_MSG);
+      await metadata.initMetadata(...validatorData).should.be.rejectedWith(ERROR_MSG);
+      validatorData[10] = miningKey;
+      await metadata.initMetadata(...validatorData).should.be.fulfilled;
+      await metadata.initMetadata(...validatorData).should.be.rejectedWith(ERROR_MSG);
+
+      (await metadata.validators.call(miningKey)).should.be.deep.equal([
+        toHex("Djamshut"),
+        toHex("Roosvelt"),
+        pad(web3.toHex("123asd")),
+        "Moskva",
+        toHex("ZZ"),
+        pad(web3.toHex("234")),
+        new web3.BigNumber(23423),
+        new web3.BigNumber(123),
+        new web3.BigNumber(0),
+        new web3.BigNumber(3)
+      ]);
+
+      validatorData[7] = 0;
+      validatorData[10] = miningKey2;
+      await metadata.initMetadata(...validatorData).should.be.rejectedWith(ERROR_MSG);
+      validatorData[7] = 123;
+      await metadata.initMetadata(...validatorData).should.be.fulfilled;
+
+      (await metadata.validators.call(miningKey2)).should.be.deep.equal([
+        toHex("Djamshut"),
+        toHex("Roosvelt"),
+        pad(web3.toHex("123asd")),
+        "Moskva",
+        toHex("ZZ"),
+        pad(web3.toHex("234")),
+        new web3.BigNumber(23423),
+        new web3.BigNumber(123),
+        new web3.BigNumber(0),
+        new web3.BigNumber(3)
+      ]);
+
+      validatorData[10] = miningKey3;
+      await metadata.initMetadataDisable({from: accounts[8]}).should.be.rejectedWith(ERROR_MSG);
+      await metadata.initMetadataDisable().should.be.fulfilled;
+      (await metadata.initMetadataDisabled.call()).should.be.equal(true);
+      await metadata.initMetadata(...validatorData).should.be.rejectedWith(ERROR_MSG);
+    });
+  });
+  
   describe('#getMiningByVotingKey', async () => {
     it('happy path', async () => {
       let actual = await metadata.getMiningByVotingKey.call(votingKey);
@@ -280,8 +345,10 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       await metadata.changeRequest(...newMetadata, {from: votingKey}).should.be.fulfilled;
       await metadata.confirmPendingChange(miningKey, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
       await metadata.confirmPendingChange(miningKey, {from: votingKey2});
+      await metadata.finalize(miningKey, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
       await metadata.confirmPendingChange(miningKey, {from: votingKey3});
-      const {logs} = await metadata.finalize(miningKey, {from: votingKey});
+      const {logs} = await metadata.finalize(miningKey, {from: votingKey}).should.be.fulfilled;
+      await metadata.finalize(miningKey2, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
       const validators = await metadata.validators.call(miningKey);
       validators.should.be.deep.equal([
         toHex("Feodosiy"),
@@ -321,22 +388,35 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
   describe('#setProxyAddress', async () => {
     let newProxy = "0xfb9c7fc2a00dffc53948e3bbeb11f3d4b56c31b8";
     it('can request a new proxy address', async () => {
-      "0x0000000000000000000000000000000000000000".should.be.equal
-        (await metadata.pendingProxyStorage.call());
+      "0x0000000000000000000000000000000000000000".should.be.equal(
+        await metadata.pendingProxyStorage.call()
+      );
       (await metadata.proxyStorage.call()).should.be.equal(proxyStorageMock.address);
+      await metadata.confirmNewProxyAddress(newProxy, {from: votingKey2}).should.be.rejectedWith(ERROR_MSG);
       await metadata.setProxyAddress(newProxy, {from: miningKey}).should.be.rejectedWith(ERROR_MSG);
       const {logs} = await metadata.setProxyAddress(newProxy, {from: votingKey}).should.be.fulfilled;
       (await metadata.pendingProxyStorage.call()).should.be.equal(newProxy);
       (await metadata.pendingProxyConfirmations.call(newProxy))[0].should.be.bignumber.deep.equal(1);
       logs[0].event.should.be.equal("RequestForNewProxy");
       logs[0].args.newProxyAddress.should.be.equal(newProxy);
-      await metadata.confirmNewProxyAddress(newProxy, {from :votingKey2}).should.be.fulfilled;
+      await metadata.setProxyAddress(newProxy, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await metadata.confirmNewProxyAddress(newProxy, {from: votingKey2}).should.be.fulfilled;
       (await metadata.pendingProxyConfirmations.call(newProxy))[0].should.be.bignumber.deep.equal(2);
+      true.should.be.equal(
+        await metadata.isAddressAlreadyVotedProxy.call(newProxy, votingKey)
+      );
+      true.should.be.equal(
+        await metadata.isAddressAlreadyVotedProxy.call(newProxy, votingKey2)
+      );
+      false.should.be.equal(
+        await metadata.isAddressAlreadyVotedProxy.call(newProxy, votingKey3)
+      );
       let final = await metadata.confirmNewProxyAddress(newProxy, {from: votingKey3}).should.be.fulfilled;
       final.logs[0].event.should.be.equal("ChangeProxyStorage");
       final.logs[0].args.newProxyAddress.should.be.equal(newProxy);
-      "0x0000000000000000000000000000000000000000".should.be.equal
-        (await metadata.pendingProxyStorage.call());
+      "0x0000000000000000000000000000000000000000".should.be.equal(
+        await metadata.pendingProxyStorage.call()
+      );
       (await metadata.proxyStorage.call()).should.be.equal(newProxy);
     })
   })

--- a/test/mockContracts/KeysManagerMock.sol
+++ b/test/mockContracts/KeysManagerMock.sol
@@ -7,4 +7,8 @@ contract KeysManagerMock is KeysManager {
     function setProxyStorage(address _proxyStorage) public {
         addressStorage[keccak256("proxyStorage")] = _proxyStorage;
     }
+
+    function setInitEnabled() public {
+    	boolStorage[INIT_DISABLED] = false;
+    }
 }

--- a/test/poa_network_consensus_test.js
+++ b/test/poa_network_consensus_test.js
@@ -12,14 +12,17 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
   let proxyStorageMock;
   let masterOfCeremony = accounts[0];
   beforeEach(async () => {
-    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
+    await PoaNetworkConsensus.new('0x0000000000000000000000000000000000000000', []).should.be.rejectedWith(ERROR_MSG);
+    poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []).should.be.fulfilled;;
     
     proxyStorageMock = await ProxyStorageMock.new();
     const proxyStorageEternalStorage = await EternalStorageProxy.new(0, proxyStorageMock.address);
     proxyStorageMock = await ProxyStorageMock.at(proxyStorageEternalStorage.address);
     await proxyStorageMock.init(poaNetworkConsensus.address).should.be.fulfilled;
     
-    await poaNetworkConsensus.setProxyStorage(proxyStorageMock.address);
+    await poaNetworkConsensus.setProxyStorage(proxyStorageMock.address).should.be.fulfilled;
+    await poaNetworkConsensus.setProxyStorage(proxyStorageMock.address).should.be.rejectedWith(ERROR_MSG);
+    
     await proxyStorageMock.initializeAddresses(
       accounts[0],
       accounts[0],
@@ -184,6 +187,7 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
       (await poaNetworkConsensus.isValidator.call(accounts[1])).should.be.equal(true);
       (await poaNetworkConsensus.isValidator.call(accounts[2])).should.be.equal(false);
       
+      await poaNetworkConsensus.swapValidatorKey(accounts[2], accounts[3]).should.be.rejectedWith(ERROR_MSG);
       await poaNetworkConsensus.swapValidatorKey(accounts[2], accounts[1]).should.be.fulfilled;
       await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
 

--- a/test/voting_to_change_keys_upgrade_test.js
+++ b/test/voting_to_change_keys_upgrade_test.js
@@ -71,32 +71,47 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
 
   describe('#createBallot', async () => {
     it('happy path', async () => {
-      await proxyStorageMock.setVotingContractMock(masterOfCeremony);
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+      await keysManager.swapMiningKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(votingKey, accounts[3]).should.be.fulfilled;
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
       const id = await voting.nextBallotId.call();
+      
+      await voting.createBallot(
+        VOTING_START_DATE, // _startTime
+        VOTING_END_DATE,   // _endTime
+        accounts[4],       // _affectedKey
+        1,                 // _affectedKeyType (MiningKey)
+        accounts[5],       // _miningKey
+        1,                 // _ballotType (KeyAdding)
+        "memo",            // _memo
+        {from: miningKeyForVotingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
+      
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
         accounts[3],       // _affectedKey
         1,                 // _affectedKeyType (MiningKey)
-        accounts[2],       // _miningKey
+        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
         "memo",            // _memo
-        {from: miningKeyForVotingKey}
+        {from: votingKey}
       ).should.be.rejectedWith(ERROR_MSG);
+      
       const {logs} = await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[3],       // _affectedKey
+        accounts[4],       // _affectedKey
         1,                 // _affectedKeyType (MiningKey)
-        accounts[2],       // _miningKey
+        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
         "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
+      
       const startTime = await voting.getStartTime.call(id.toNumber());
       const endTime = await voting.getEndTime.call(id.toNumber());
       const keysManagerFromContract = await voting.getKeysManager.call();
@@ -906,6 +921,81 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       (await voting.getIsFinalized.call(1)).should.be.equal(true);
     });
   })
+
+  describe('#migrate', async () => {
+    it('should copy a ballot to the new contract', async () => {
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+      await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
+      await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
+
+      VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
+      VOTING_END_DATE = moment.utc().add(10, 'days').unix();
+      const id = await voting.nextBallotId.call();
+      await voting.createBallot(
+        VOTING_START_DATE, // _startTime
+        VOTING_END_DATE,   // _endTime
+        accounts[3],       // _affectedKey
+        1,                 // _affectedKeyType (MiningKey)
+        accounts[2],       // _miningKey
+        1,                 // _ballotType (KeyAdding)
+        "memo",            // _memo
+        {from: votingKey}
+      ).should.be.fulfilled;
+
+      let votingNew = await VotingToChangeKeysMock.new();
+      const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
+      votingNew = await VotingToChangeKeysMock.at(votingEternalStorage.address);
+
+      await votingNew.migrateBasicOne(
+        id,
+        voting.address,
+        await voting.getQuorumState.call(id),
+        await voting.getIndex.call(id),
+        await voting.getCreator.call(id),
+        await voting.getMemo.call(id),
+        [accounts[3], accounts[4], accounts[5]]
+      );
+
+      (await votingNew.getStartTime.call(id)).should.be.bignumber.equal(VOTING_START_DATE);
+      (await votingNew.getEndTime.call(id)).should.be.bignumber.equal(VOTING_END_DATE);
+      (await votingNew.getAffectedKey.call(id)).should.be.equal(accounts[3]);
+      (await votingNew.getAffectedKeyType.call(id)).should.be.bignumber.equal(1);
+      (await votingNew.getMiningKey.call(id)).should.be.equal(accounts[2]);
+      (await votingNew.getTotalVoters.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getProgress.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getIsFinalized.call(id)).should.be.equal(false);
+      (await votingNew.getQuorumState.call(id)).should.be.bignumber.equal(1);
+      (await votingNew.getBallotType.call(id)).should.be.bignumber.equal(1);
+      (await votingNew.getIndex.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(3);
+      (await votingNew.getCreator.call(id)).should.be.equal(accounts[1]);
+      (await votingNew.getMemo.call(id)).should.be.equal("memo");
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[1])).should.be.equal(false);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[2])).should.be.equal(false);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[3])).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[4])).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[5])).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[6])).should.be.equal(false);
+
+      (await votingNew.nextBallotId.call()).should.be.bignumber.equal(0);
+      (await votingNew.activeBallotsLength.call()).should.be.bignumber.equal(0);
+      (await votingNew.validatorActiveBallots.call(accounts[1])).should.be.bignumber.equal(0);
+      await votingNew.migrateBasicAll(voting.address, {from: accounts[6]}).should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateBasicAll('0x0000000000000000000000000000000000000000').should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateBasicAll(voting.address).should.be.fulfilled;
+      await votingNew.migrateBasicAll(voting.address).should.be.fulfilled;
+      (await votingNew.nextBallotId.call()).should.be.bignumber.equal(1);
+      (await votingNew.activeBallotsLength.call()).should.be.bignumber.equal(1);
+      (await votingNew.validatorActiveBallots.call(accounts[1])).should.be.bignumber.equal(1);
+      (await votingNew.migrateDisabled.call()).should.be.equal(false);
+      await votingNew.migrateDisable({from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateDisable().should.be.fulfilled;
+      (await votingNew.migrateDisabled.call()).should.be.equal(true);
+      await votingNew.migrateBasicAll(voting.address).should.be.rejectedWith(ERROR_MSG);
+    });
+  });
 });
 
 

--- a/test/voting_to_change_min_threshold_upgrade_test.js
+++ b/test/voting_to_change_min_threshold_upgrade_test.js
@@ -52,6 +52,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     voting = await Voting.new();
     const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
     voting = await Voting.at(votingEternalStorage.address);
+    await voting.init(172800, 0).should.be.rejectedWith(ERROR_MSG);
     await voting.init(172800, 3).should.be.fulfilled;
 
     const votingNew = await VotingNew.new();
@@ -425,6 +426,60 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await voting.setTime(VOTING_END_DATE+1);
       await voting.finalize(1, {from: votingKey2}).should.be.fulfilled;
       (await voting.getIsFinalized.call(1)).should.be.equal(true);
+    });
+  });
+
+  describe('#migrate', async () => {
+    it('should copy a ballot to the new contract', async () => {
+      VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
+      VOTING_END_DATE = moment.utc().add(10, 'days').unix();
+      const id = await voting.nextBallotId.call();
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, 4, "memo", {from: votingKey}).should.be.fulfilled;
+
+      let votingNew = await Voting.new();
+      const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
+      votingNew = await Voting.at(votingEternalStorage.address);
+
+      await votingNew.migrateBasicOne(
+        id,
+        voting.address,
+        await voting.getQuorumState.call(id),
+        await voting.getIndex.call(id),
+        await voting.getCreator.call(id),
+        await voting.getMemo.call(id),
+        [votingKey, votingKey2, votingKey3]
+      );
+
+      (await votingNew.getStartTime.call(id)).should.be.bignumber.equal(VOTING_START_DATE);
+      (await votingNew.getEndTime.call(id)).should.be.bignumber.equal(VOTING_END_DATE);
+      (await votingNew.getTotalVoters.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getProgress.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getIsFinalized.call(id)).should.be.equal(false);
+      (await votingNew.getQuorumState.call(id)).should.be.bignumber.equal(1);
+      (await votingNew.getIndex.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(3);
+      (await votingNew.getCreator.call(id)).should.be.equal(accounts[1]);
+      (await votingNew.getMemo.call(id)).should.be.equal("memo");
+      (await votingNew.getProposedValue.call(id)).should.be.bignumber.equal(4);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, votingKey)).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, votingKey2)).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, votingKey3)).should.be.equal(true);
+
+      (await votingNew.nextBallotId.call()).should.be.bignumber.equal(0);
+      (await votingNew.activeBallotsLength.call()).should.be.bignumber.equal(0);
+      (await votingNew.validatorActiveBallots.call(accounts[1])).should.be.bignumber.equal(0);
+      await votingNew.migrateBasicAll(voting.address, {from: accounts[6]}).should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateBasicAll('0x0000000000000000000000000000000000000000').should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateBasicAll(voting.address).should.be.fulfilled;
+      await votingNew.migrateBasicAll(voting.address).should.be.fulfilled;
+      (await votingNew.nextBallotId.call()).should.be.bignumber.equal(1);
+      (await votingNew.activeBallotsLength.call()).should.be.bignumber.equal(1);
+      (await votingNew.validatorActiveBallots.call(accounts[1])).should.be.bignumber.equal(1);
+      (await votingNew.migrateDisabled.call()).should.be.equal(false);
+      await votingNew.migrateDisable({from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateDisable().should.be.fulfilled;
+      (await votingNew.migrateDisabled.call()).should.be.equal(true);
+      await votingNew.migrateBasicAll(voting.address).should.be.rejectedWith(ERROR_MSG);
     });
   });
 })

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -456,6 +456,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       (await voting.getCreator.call(votingIdForSecond)).should.be.equal(miningKeyForVotingKey);
       (await voting.getMemo.call(votingIdForSecond)).should.be.equal("memo");
     });
+
     it('allowed at once after all validators gave their votes', async () => {
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
@@ -516,6 +517,75 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       (await voting.getIsFinalized.call(1)).should.be.equal(true);
     });
   });
+
+  describe('#migrate', async () => {
+    it('should copy a ballot to the new contract', async () => {
+      proxyStorageMock.setVotingContractMock(accounts[0]);
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+      proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
+      await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
+      await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
+
+      VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
+      VOTING_END_DATE = moment.utc().add(10, 'days').unix();
+      const id = await voting.nextBallotId.call();
+
+      await voting.createBallot(
+        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", {from: votingKey}
+      ).should.be.fulfilled;
+
+      let votingNew = await VotingToChangeProxyAddress.new();
+      const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
+      votingNew = await VotingToChangeProxyAddress.at(votingEternalStorage.address);
+
+      await votingNew.migrateBasicOne(
+        id,
+        voting.address,
+        await voting.getQuorumState.call(id),
+        await voting.getIndex.call(id),
+        await voting.getCreator.call(id),
+        await voting.getMemo.call(id),
+        [accounts[3], accounts[4], accounts[5]]
+      );
+
+      (await votingNew.getStartTime.call(id)).should.be.bignumber.equal(VOTING_START_DATE);
+      (await votingNew.getEndTime.call(id)).should.be.bignumber.equal(VOTING_END_DATE);
+      (await votingNew.getTotalVoters.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getProgress.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getIsFinalized.call(id)).should.be.equal(false);
+      (await votingNew.getQuorumState.call(id)).should.be.bignumber.equal(1);
+      (await votingNew.getIndex.call(id)).should.be.bignumber.equal(0);
+      (await votingNew.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(1);
+      (await votingNew.getCreator.call(id)).should.be.equal(accounts[1]);
+      (await votingNew.getMemo.call(id)).should.be.equal("memo");
+      (await votingNew.getProposedValue.call(id)).should.be.equal(accounts[5]);
+      (await votingNew.getContractType.call(id)).should.be.bignumber.equal(1);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[1])).should.be.equal(false);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[2])).should.be.equal(false);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[3])).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[4])).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[5])).should.be.equal(true);
+      (await votingNew.hasMiningKeyAlreadyVoted.call(id, accounts[6])).should.be.equal(false);
+
+      (await votingNew.nextBallotId.call()).should.be.bignumber.equal(0);
+      (await votingNew.activeBallotsLength.call()).should.be.bignumber.equal(0);
+      (await votingNew.validatorActiveBallots.call(accounts[1])).should.be.bignumber.equal(0);
+      await votingNew.migrateBasicAll(voting.address, {from: accounts[6]}).should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateBasicAll('0x0000000000000000000000000000000000000000').should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateBasicAll(voting.address).should.be.fulfilled;
+      await votingNew.migrateBasicAll(voting.address).should.be.fulfilled;
+      (await votingNew.nextBallotId.call()).should.be.bignumber.equal(1);
+      (await votingNew.activeBallotsLength.call()).should.be.bignumber.equal(1);
+      (await votingNew.validatorActiveBallots.call(accounts[1])).should.be.bignumber.equal(1);
+      (await votingNew.migrateDisabled.call()).should.be.equal(false);
+      await votingNew.migrateDisable({from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+      await votingNew.migrateDisable().should.be.fulfilled;
+      (await votingNew.migrateDisabled.call()).should.be.equal(true);
+      await votingNew.migrateBasicAll(voting.address).should.be.rejectedWith(ERROR_MSG);
+    });
+  });
+
 })
 
 async function deployAndTest({

--- a/test/voting_to_manage_emission_funds_test.js
+++ b/test/voting_to_manage_emission_funds_test.js
@@ -620,6 +620,28 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       );
     });
 
+    it('send funds to receiver if most votes are for sending', async () => {
+      await addValidator(votingKey2, miningKey2);
+      await addValidator(votingKey3, miningKey3);
+
+      const receiverInitBalance = await web3.eth.getBalance(receiver);
+
+      (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(emissionFundsInitBalance);
+
+      await voting.setTime(VOTING_START_DATE);
+      await voting.vote(id, choice.send, {from: votingKey}).should.be.fulfilled;
+      await voting.vote(id, choice.send, {from: votingKey2}).should.be.fulfilled;
+      await voting.vote(id, choice.burn, {from: votingKey3}).should.be.fulfilled;
+
+      (await voting.getIsFinalized.call(id)).should.be.equal(true);
+      (await voting.getQuorumState.call(id)).should.be.bignumber.equal(2);
+      (await voting.getTotalVoters.call(id)).should.be.bignumber.equal(3);
+      (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(0);
+      (await web3.eth.getBalance(receiver)).should.be.bignumber.equal(
+        receiverInitBalance.add(emissionFundsInitBalance)
+      );
+    });
+
     it('burn funds if most votes are for burning', async () => {
       await addValidator(votingKey2, miningKey2);
       await addValidator(votingKey3, miningKey3);

--- a/test/voting_to_manage_emission_funds_upgrade_test.js
+++ b/test/voting_to_manage_emission_funds_upgrade_test.js
@@ -626,6 +626,28 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       );
     });
 
+    it('send funds to receiver if most votes are for sending', async () => {
+      await addValidator(votingKey2, miningKey2);
+      await addValidator(votingKey3, miningKey3);
+
+      const receiverInitBalance = await web3.eth.getBalance(receiver);
+
+      (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(emissionFundsInitBalance);
+
+      await voting.setTime(VOTING_START_DATE);
+      await voting.vote(id, choice.send, {from: votingKey}).should.be.fulfilled;
+      await voting.vote(id, choice.send, {from: votingKey2}).should.be.fulfilled;
+      await voting.vote(id, choice.burn, {from: votingKey3}).should.be.fulfilled;
+
+      (await voting.getIsFinalized.call(id)).should.be.equal(true);
+      (await voting.getQuorumState.call(id)).should.be.bignumber.equal(2);
+      (await voting.getTotalVoters.call(id)).should.be.bignumber.equal(3);
+      (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(0);
+      (await web3.eth.getBalance(receiver)).should.be.bignumber.equal(
+        receiverInitBalance.add(emissionFundsInitBalance)
+      );
+    });
+
     it('burn funds if most votes are for burning', async () => {
       await addValidator(votingKey2, miningKey2);
       await addValidator(votingKey3, miningKey3);


### PR DESCRIPTION
**(Mandatory) Description**
Unit tests didn't fully cover smart contracts as it was mentioned in https://github.com/poanetwork/poa-network-consensus-contracts/issues/114. Now all tests are extended.

Use `npm run coverage` to see an actual `solidity-coverage` report:

![image](https://user-images.githubusercontent.com/33550681/41112245-1b08121c-6a87-11e8-9694-1fa98aea3d62.png)

![image](https://user-images.githubusercontent.com/33550681/41112272-2df50ace-6a87-11e8-843c-6650b83840f9.png)

![image](https://user-images.githubusercontent.com/33550681/41112289-3560591c-6a87-11e8-9c79-3edee594737b.png)

![image](https://user-images.githubusercontent.com/33550681/41112305-3cd12bb8-6a87-11e8-93c7-1c87eb2865ff.png)

**(Mandatory) What is it: (Fix), (Feature) or (Refactor)**
(Feature)