### PR TITLE
(Feature) Add extra getters for Voting DApp optimization

### DIFF
--- a/contracts/ValidatorMetadata.sol
+++ b/contracts/ValidatorMetadata.sol
@@ -64,6 +64,14 @@ contract ValidatorMetadata is EternalStorage {
         return addressStorage[PENDING_PROXY_STORAGE];
     }
 
+    function getValidatorName(address _miningKey) public view returns (
+        bytes32 firstName,
+        bytes32 lastName
+    ) {
+        firstName = _getFirstName(false, _miningKey);
+        lastName = _getLastName(false, _miningKey);
+    }
+
     function validators(address _miningKey) public view returns (
         bytes32 firstName,
         bytes32 lastName,

--- a/contracts/VotingToChangeKeys.sol
+++ b/contracts/VotingToChangeKeys.sol
@@ -129,6 +129,38 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange {
         return ballotId;
     }
 
+    function getBallotInfo(uint256 _id) public view returns(
+        uint256 startTime,
+        uint256 endTime,
+        address affectedKey,
+        uint256 affectedKeyType,
+        address newVotingKey,
+        address newPayoutKey,
+        address miningKey,
+        uint256 totalVoters,
+        int256 progress,
+        bool isFinalized,
+        uint256 ballotType,
+        address creator,
+        string memo,
+        bool canBeFinalizedNow
+    ) {
+        startTime = getStartTime(_id);
+        endTime = getEndTime(_id);
+        affectedKey = getAffectedKey(_id);
+        affectedKeyType = getAffectedKeyType(_id);
+        newVotingKey = getNewVotingKey(_id);
+        newPayoutKey = getNewPayoutKey(_id);
+        miningKey = getMiningKey(_id);
+        totalVoters = getTotalVoters(_id);
+        progress = getProgress(_id);
+        isFinalized = getIsFinalized(_id);
+        ballotType = getBallotType(_id);
+        creator = getCreator(_id);
+        memo = getMemo(_id);
+        canBeFinalizedNow = this.canBeFinalizedNow(_id);
+    }
+
     function getAffectedKey(uint256 _id) public view returns(address) {
         return addressStorage[
             keccak256(abi.encodePacked(VOTING_STATE, _id, AFFECTED_KEY))

--- a/contracts/VotingToChangeMinThreshold.sol
+++ b/contracts/VotingToChangeMinThreshold.sol
@@ -28,6 +28,30 @@ contract VotingToChangeMinThreshold is IVotingToChangeMinThreshold, VotingToChan
         _setProposedValue(ballotId, _proposedValue);
     }
 
+    function getBallotInfo(uint256 _id, address _votingKey) public view returns(
+        uint256 startTime,
+        uint256 endTime,
+        uint256 totalVoters,
+        int256 progress,
+        bool isFinalized,
+        uint256 proposedValue,
+        address creator,
+        string memo,
+        bool canBeFinalizedNow,
+        bool hasAlreadyVoted
+    ) {
+        startTime = getStartTime(_id);
+        endTime = getEndTime(_id);
+        totalVoters = getTotalVoters(_id);
+        progress = getProgress(_id);
+        isFinalized = getIsFinalized(_id);
+        proposedValue = getProposedValue(_id);
+        creator = getCreator(_id);
+        memo = getMemo(_id);
+        canBeFinalizedNow = this.canBeFinalizedNow(_id);
+        hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
+    }
+
     function getProposedValue(uint256 _id) public view returns(uint256) {
         return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, PROPOSED_VALUE))];
     }

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -28,6 +28,32 @@ contract VotingToChangeProxyAddress is IVotingToChangeProxyAddress, VotingToChan
         _setContractType(ballotId, _contractType);
     }
 
+    function getBallotInfo(uint256 _id, address _votingKey) public view returns(
+        uint256 startTime,
+        uint256 endTime,
+        uint256 totalVoters,
+        int256 progress,
+        bool isFinalized,
+        address proposedValue,
+        uint256 contractType,
+        address creator,
+        string memo,
+        bool canBeFinalizedNow,
+        bool hasAlreadyVoted
+    ) {
+        startTime = getStartTime(_id);
+        endTime = getEndTime(_id);
+        totalVoters = getTotalVoters(_id);
+        progress = getProgress(_id);
+        isFinalized = getIsFinalized(_id);
+        proposedValue = getProposedValue(_id);
+        contractType = getContractType(_id);
+        creator = getCreator(_id);
+        memo = getMemo(_id);
+        canBeFinalizedNow = this.canBeFinalizedNow(_id);
+        hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
+    }
+
     function getContractType(uint256 _id) public view returns(uint256) {
         return uintStorage[
             keccak256(abi.encodePacked(VOTING_STATE, _id, CONTRACT_TYPE))

--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -92,6 +92,32 @@ contract VotingToManageEmissionFunds is VotingTo {
         return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, AMOUNT))];
     }
 
+    function getBallotInfo(uint256 _id, address _votingKey) public view returns(
+        uint256 startTime,
+        uint256 endTime,
+        bool isFinalized,
+        address creator,
+        string memo,
+        bool hasAlreadyVoted,
+        uint256 amount,
+        uint256 burnVotes,
+        uint256 freezeVotes,
+        uint256 sendVotes,
+        address receiver
+    ) {
+        startTime = getStartTime(_id);
+        endTime = getEndTime(_id);
+        isFinalized = getIsFinalized(_id);
+        creator = getCreator(_id);
+        memo = getMemo(_id);
+        hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
+        amount = getAmount(_id);
+        burnVotes = getBurnVotes(_id);
+        freezeVotes = getFreezeVotes(_id);
+        sendVotes = getSendVotes(_id);
+        receiver = getReceiver(_id);
+    }
+
     function getBurnVotes(uint256 _id) public view returns(uint256) {
         return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, BURN_VOTES))];
     }


### PR DESCRIPTION
- (Mandatory) Description
This PR is a part of `Voting DApp` optimization. It adds `ValidatorMetadata.getValidatorName` and `VotingTo*.getBallotInfo` getters to make `Voting DApp` be able to read ballot's data from new smart contracts in a single request.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Feature)