### PR TITLE
(Fix) "Stack too deep" error in VotingToChangeKeys.getBallotInfo

### DIFF
--- a/contracts/VotingToChangeKeys.sol
+++ b/contracts/VotingToChangeKeys.sol
@@ -158,7 +158,7 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange {
         ballotType = getBallotType(_id);
         creator = getCreator(_id);
         memo = getMemo(_id);
-        canBeFinalizedNow = this.canBeFinalizedNow(_id);
+        canBeFinalizedNow = _canBeFinalizedNow(_id);
     }
 
     function getAffectedKey(uint256 _id) public view returns(address) {

--- a/contracts/VotingToChangeMinThreshold.sol
+++ b/contracts/VotingToChangeMinThreshold.sol
@@ -48,7 +48,7 @@ contract VotingToChangeMinThreshold is IVotingToChangeMinThreshold, VotingToChan
         proposedValue = getProposedValue(_id);
         creator = getCreator(_id);
         memo = getMemo(_id);
-        canBeFinalizedNow = this.canBeFinalizedNow(_id);
+        canBeFinalizedNow = _canBeFinalizedNow(_id);
         hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
     }
 

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -50,7 +50,7 @@ contract VotingToChangeProxyAddress is IVotingToChangeProxyAddress, VotingToChan
         contractType = getContractType(_id);
         creator = getCreator(_id);
         memo = getMemo(_id);
-        canBeFinalizedNow = this.canBeFinalizedNow(_id);
+        canBeFinalizedNow = _canBeFinalizedNow(_id);
         hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
     }
 


### PR DESCRIPTION
- (Mandatory) Description
This PR fixes "Stack too deep" compilation error in the new `VotingToChangeKeys.getBallotInfo` getter that was added in #129.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Fix)