### PR TITLE
(Feature) Block Reward emission by time

### DIFF
--- a/contracts/BlockReward.sol
+++ b/contracts/BlockReward.sol
@@ -3,9 +3,13 @@ pragma solidity ^0.4.24;
 import "./interfaces/IBlockReward.sol";
 import "./interfaces/IKeysManager.sol";
 import "./interfaces/IProxyStorage.sol";
+import "./interfaces/IPoaNetworkConsensus.sol";
+import "./libs/SafeMath.sol";
 
 
 contract BlockReward is IBlockReward {
+    using SafeMath for uint256;
+
     uint256 public blockRewardAmount;
     uint256 public emissionFundsAmount;
 
@@ -16,7 +20,12 @@ contract BlockReward is IBlockReward {
     address public emissionFunds;
     IProxyStorage public proxyStorage;
 
-    event Rewarded(address[] receivers, uint256[] rewards);
+    uint256 public hbbftLastTime;
+    uint256 public hbbftKeyIndex;
+    uint256 public hbbftTimeThreshold;
+    address[] public hbbftPayoutKeys;
+
+    event Rewarded(address[] receivers, uint256[] rewards, bool indexed isHBBFT);
 
     modifier onlySystem {
         require(msg.sender == SYSTEM_ADDRESS);
@@ -27,14 +36,25 @@ contract BlockReward is IBlockReward {
         address _proxyStorage,
         address _emissionFunds,
         uint256 _blockRewardAmount,
-        uint256 _emissionFundsAmount
+        uint256 _emissionFundsAmount,
+        uint256 _hbbftTimeThreshold
     ) public {
         require(_proxyStorage != address(0));
         require(_blockRewardAmount != 0);
+        require(_hbbftTimeThreshold != 0);
         proxyStorage = IProxyStorage(_proxyStorage);
         emissionFunds = _emissionFunds;
         blockRewardAmount = _blockRewardAmount;
         emissionFundsAmount = _emissionFundsAmount;
+        hbbftTimeThreshold = _hbbftTimeThreshold;
+    }
+
+    function getHBBFTPayoutKeys() public view returns(address[]) {
+        return hbbftPayoutKeys;
+    }
+
+    function getTime() public view returns(uint256) {
+        return now;
     }
 
     function reward(address[] benefactors, uint16[] kind)
@@ -51,25 +71,63 @@ contract BlockReward is IBlockReward {
         require(_isMiningActive(miningKey));
 
         address payoutKey = _getPayoutByMining(miningKey);
-        uint256 receiversLength = 2;
 
-        if (emissionFunds == address(0) || emissionFundsAmount == 0) {
-            receiversLength = 1;
-        }
-
-        address[] memory receivers = new address[](receiversLength);
-        uint256[] memory rewards = new uint256[](receiversLength);
+        address[] memory receivers = new address[](2);
+        uint256[] memory rewards = new uint256[](2);
 
         receivers[0] = (payoutKey != address(0)) ? payoutKey : miningKey;
         rewards[0] = blockRewardAmount;
+        receivers[1] = emissionFunds;
+        rewards[1] = emissionFundsAmount;
 
-        if (receiversLength == 2) {
-            receivers[1] = emissionFunds;
-            rewards[1] = emissionFundsAmount;
+        emit Rewarded(receivers, rewards, false);
+    
+        return (receivers, rewards);
+    }
+
+    function rewardHBBFT()
+        external
+        onlySystem
+        returns (address[], uint256[])
+    {
+        uint256 currentTime = getTime();
+        address[] memory receivers;
+        uint256[] memory rewards;
+        uint256 keysNumberToReward;
+        uint256 n;
+        
+        if (hbbftPayoutKeys.length == 0) { // the first call
+            hbbftLastTime = currentTime.sub(hbbftTimeThreshold);
+            _hbbftRefreshPayoutKeys();
         }
 
-        emit Rewarded(receivers, rewards);
-    
+        keysNumberToReward = currentTime.sub(hbbftLastTime).div(hbbftTimeThreshold);
+
+        if (keysNumberToReward == 0 || hbbftPayoutKeys.length == 0) {
+            receivers = new address[](0);
+            rewards = new uint256[](0);
+            return (receivers, rewards);
+        }
+
+        receivers = new address[](keysNumberToReward.add(1));
+        rewards = new uint256[](receivers.length);
+
+        for (n = 0; n < keysNumberToReward; n++) {
+            receivers[n] = hbbftPayoutKeys[hbbftKeyIndex];
+            rewards[n] = blockRewardAmount;
+            hbbftLastTime += hbbftTimeThreshold;
+            hbbftKeyIndex++;
+
+            if (hbbftKeyIndex >= hbbftPayoutKeys.length) {
+                _hbbftRefreshPayoutKeys();
+            }
+        }
+
+        receivers[n] = emissionFunds;
+        rewards[n] = emissionFundsAmount.mul(keysNumberToReward);
+
+        emit Rewarded(receivers, rewards, true);
+
         return (receivers, rewards);
     }
 
@@ -80,6 +138,20 @@ contract BlockReward is IBlockReward {
     {
         IKeysManager keysManager = IKeysManager(proxyStorage.getKeysManager());
         return keysManager.getPayoutByMining(_miningKey);
+    }
+
+    function _hbbftRefreshPayoutKeys() private {
+        IPoaNetworkConsensus poa = IPoaNetworkConsensus(proxyStorage.getPoaConsensus());
+        address[] memory validators = poa.getValidators();
+
+        delete hbbftPayoutKeys;
+        for (uint256 i = 0; i < validators.length; i++) {
+            address miningKey = validators[i];
+            address payoutKey = _getPayoutByMining(miningKey);
+            hbbftPayoutKeys.push((payoutKey != address(0)) ? payoutKey : miningKey);
+        }
+
+        hbbftKeyIndex = 0;
     }
 
     function _isMiningActive(address _miningKey)

--- a/test/mockContracts/BlockRewardMock.sol
+++ b/test/mockContracts/BlockRewardMock.sol
@@ -4,20 +4,36 @@ import '../../contracts/BlockReward.sol';
 
 
 contract BlockRewardMock is BlockReward {
+    uint256 public time;
+
     constructor(
         address _proxyStorage,
         address _emissionFunds,
         uint256 _blockRewardAmount,
-        uint256 _emissionFundsAmount
+        uint256 _emissionFundsAmount,
+        uint256 _hbbftTimeThreshold
     ) BlockReward(
         _proxyStorage,
         _emissionFunds,
         _blockRewardAmount,
-        _emissionFundsAmount
+        _emissionFundsAmount,
+        _hbbftTimeThreshold
     ) public {
     }
 
     function setSystemAddress(address _systemAddress) public {
         SYSTEM_ADDRESS = _systemAddress;
+    }
+
+    function setTime(uint256 _time) public {
+        time = _time;
+    }
+
+    function getTime() public view returns(uint256) {
+        if (time == 0) {
+            return now;
+        } else {
+            return time;
+        }
     }
 }

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -14,6 +14,10 @@ async function addValidators({
   await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
 }
 
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
 let arrayOfHundredAddresses = [
   "0xa6Bf70bd230867c870eF13631D7EFf1AE8Ab85c9",
   "0x00b5F428905DEA1a67940093fFeaCeee58cA91Ae",
@@ -116,4 +120,6 @@ let arrayOfHundredAddresses = [
   "0xA95C3543636F5d62Accf8d2B8Ae06bca1aDf679F",
   "0x4209C9eA64fb4fA437eb950B3839a43C99d96c06",
 ]
+
 exports.addValidators = addValidators;
+exports.getRandomInt = getRandomInt;


### PR DESCRIPTION
- (Mandatory) Description
These changes complement `BlockReward` contract by `rewardHBBFT` function that implements the logic described in https://github.com/poanetwork/RFC/issues/16. Also, some unit tests were added to `test/block_reward_test.js` to check that logic. The `rewardHBBFT` function must be called by HBBFT engine (https://github.com/poanetwork/hbbft) when creating each block.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Feature)