### PR TITLE
(Fix) Add keeping of RewardByBlock and VotingToManageEmissionFunds addresses to ProxyStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,41 +36,55 @@ Select `0.4.24` Solidity compiler version. Set `Optimize` to `true`.
 
 Compile and deploy contracts in the next sequence:
 
-- `ProxyStorage_flat.sol` - Select contract `ProxyStorage`.
-- `EternalStorageProxy_flat.sol` - Select contract `EternalStorageProxy` with constructor parameters: <br />
+- `ProxyStorage_flat.sol` - Deploy `ProxyStorage` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - equal to zero,
 `_implementationAddress` - address of ProxyStorage contract.
--  Make a call to `ProxyStorage init` with `_poaConsensus` parameter equal to the address of poaConsensus contract, using the address of `EternalStorageProxy` and ABI of `ProxyStorage`.
--  Select `poaNetworkConsensus` contract and send transaction `setProxyStorage` with the address of ProxyStorage contract.
-- `KeysManager_flat.sol` - Select contract `KeysManager`.
-- `EternalStorageProxy_flat.sol` - Select contract `EternalStorageProxy` with constructor parameters: <br />
+-  Make a call to `ProxyStorage init` with `_poaConsensus` parameter equal to the address of PoaNetworkConsensus contract, using the address of `EternalStorageProxy` and ABI of `ProxyStorage`.
+-  Select `PoaNetworkConsensus` contract and call `setProxyStorage` with the address of ProxyStorage contract.
+- `KeysManager_flat.sol` - Deploy `KeysManager` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of KeysManager contract.
 -  Make a call to `KeysManager init` with `_previousKeysManager` parameter equal to 0x0000000000000000000000000000000000000000, using the address of `EternalStorageProxy` and ABI of `KeysManager`.
-- `BallotsStorage_flat.sol` - Select contract `BallotsStorage`.
-- `EternalStorageProxy_flat.sol` - Select contract `EternalStorageProxy` with constructor parameters: <br />
+- `BallotsStorage_flat.sol` - Deploy `BallotsStorage` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of BallotsStorage contract.
 -  Make a call to `BallotsStorage init` with `_thresholds` parameter equal to [3, 2], using the address of `EternalStorageProxy` and ABI of `BallotsStorage`.
-- `VotingToChangeKeys_flat.sol` - Select contract `VotingToChangeKeys`.
-- `EternalStorageProxy_flat.sol` - Select contract `EternalStorageProxy` with constructor parameters: <br />
+- `VotingToChangeKeys_flat.sol` - Deploy `VotingToChangeKeys` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of VotingToChangeKeys contract.
 -  Make a call to `VotingToChangeKeys init` with `_minBallotDuration` parameter equal to `172800`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeKeys`.
-- `VotingToChangeMinThreshold_flat.sol` - Select contract `VotingToChangeMinThreshold`.
-- `EternalStorageProxy_flat.sol` - Select contract `EternalStorageProxy` with constructor parameters: <br />
+- `VotingToChangeMinThreshold_flat.sol` - Deploy `VotingToChangeMinThreshold` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of VotingToChangeMinThreshold contract.
 -  Make a call to `VotingToChangeMinThreshold init` with `_minBallotDuration` parameter equal to `172800` and `_minPossibleThreshold` parameter equal to `3`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeMinThreshold`.
-- `VotingToChangeProxyAddress_flat.sol` - Select contract `VotingToChangeProxyAddress`.
-- `EternalStorageProxy_flat.sol` - Select contract `EternalStorageProxy` with constructor parameters: <br />
+- `VotingToChangeProxyAddress_flat.sol` - Deploy `VotingToChangeProxyAddress` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of VotingToChangeProxyAddress contract.
 -  Make a call to `VotingToChangeProxyAddress init` with `_minBallotDuration` parameter equal to `172800`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeProxyAddress`.
-- `ValidatorMetadata_flat.sol` - Select contract `ValidatorMetadata`.
-- `EternalStorageProxy_flat.sol` - Select contract `EternalStorageProxy` with constructor parameters: <br />
+- `ValidatorMetadata_flat.sol` - Deploy `ValidatorMetadata` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of ValidatorMetadata contract.
+- `VotingToManageEmissionFunds_flat.sol` - Deploy `VotingToManageEmissionFunds` contract.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
+`_proxyStorage` - address of ProxyStorage contract,
+`_implementationAddress` - address of VotingToManageEmissionFunds contract.
+- `EmissionFunds_flat.sol` - Deploy `EmissionFunds` contract with constructor parameter `_votingToManageEmissionFunds` equal to `EternalStorageProxy` address of `VotingToManageEmissionFunds` contract.
+- `RewardByBlock_flat.sol` - Deploy `RewardByBlock` contract and replace `emissionFunds` constant value `0x00...` inside it with the address of deployed `EmissionFunds`. Then deploy `RewardByBlock`.
+- `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
+`_proxyStorage` - address of ProxyStorage contract,
+`_implementationAddress` - address of RewardByBlock contract.
+-  Make a call to `VotingToManageEmissionFunds init`, using the address of `EternalStorageProxy` and ABI of `VotingToManageEmissionFunds`, with the next parameters: <br />
+`_emissionFunds` - address of EmissionFunds contract,
+`_emissionReleaseTime` - your emission release unix timestamp,
+`_emissionReleaseThreshold` - your emission release threshold in seconds,
+`_distributionThreshold` - your distribution threshold in seconds.
 -  Select deployed `ProxyStorage` contract and make a call from MoC address to `initializeAddresses` with relevant addresses.
 
 ## Unit tests

--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -24,6 +24,9 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
     
     bytes32 internal constant POA_CONSENSUS =
         keccak256("poaConsensus");
+
+    bytes32 internal constant REWARD_BY_BLOCK_ETERNAL_STORAGE = 
+        keccak256("rewardByBlockEternalStorage");
     
     bytes32 internal constant VALIDATOR_METADATA_ETERNAL_STORAGE =
         keccak256("validatorMetadataEternalStorage");
@@ -36,6 +39,9 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
     
     bytes32 internal constant VOTING_TO_CHANGE_PROXY_ETERNAL_STORAGE =
         keccak256("votingToChangeProxyEternalStorage");
+
+    bytes32 internal constant VOTING_TO_MANAGE_EMISSION_FUNDS_ETERNAL_STORAGE = 
+        keccak256("votingToManageEmissionFundsEternalStorage");
 
     enum ContractTypes {
         Invalid,
@@ -54,8 +60,10 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
         address votingToChangeKeysEternalStorage,
         address votingToChangeMinThresholdEternalStorage,
         address votingToChangeProxyEternalStorage,
+        address votingToManageEmissionFundsEternalStorage,
         address ballotsStorageEternalStorage,
-        address validatorMetadataEternalStorage
+        address validatorMetadataEternalStorage,
+        address rewardByBlockEternalStorage
     );
 
     event AddressSet(uint256 contractType, address contractAddress);
@@ -102,6 +110,10 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
         return addressStorage[VOTING_TO_CHANGE_PROXY_ETERNAL_STORAGE];
     }
 
+    function getVotingToManageEmissionFunds() public view returns(address) {
+        return addressStorage[VOTING_TO_MANAGE_EMISSION_FUNDS_ETERNAL_STORAGE];
+    }
+
     function getPoaConsensus() public view returns(address) {
         return addressStorage[POA_CONSENSUS];
     }
@@ -114,13 +126,19 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
         return addressStorage[VALIDATOR_METADATA_ETERNAL_STORAGE];
     }
 
+    function getRewardByBlock() public view returns(address) {
+        return addressStorage[REWARD_BY_BLOCK_ETERNAL_STORAGE];
+    }
+
     function initializeAddresses(
         address _keysManagerEternalStorage,
         address _votingToChangeKeysEternalStorage,
         address _votingToChangeMinThresholdEternalStorage,
         address _votingToChangeProxyEternalStorage,
+        address _votingToManageEmissionFundsEternalStorage,
         address _ballotsStorageEternalStorage,
-        address _validatorMetadataEternalStorage
+        address _validatorMetadataEternalStorage,
+        address _rewardByBlockEternalStorage
     ) public {
         require(isValidator(msg.sender) || _isOwner(msg.sender));
         require(!mocInitialized());
@@ -132,18 +150,24 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
             _votingToChangeMinThresholdEternalStorage;
         addressStorage[VOTING_TO_CHANGE_PROXY_ETERNAL_STORAGE] =
             _votingToChangeProxyEternalStorage;
+        addressStorage[VOTING_TO_MANAGE_EMISSION_FUNDS_ETERNAL_STORAGE] =
+            _votingToManageEmissionFundsEternalStorage;
         addressStorage[BALLOTS_STORAGE_ETERNAL_STORAGE] =
             _ballotsStorageEternalStorage;
         addressStorage[VALIDATOR_METADATA_ETERNAL_STORAGE] =
             _validatorMetadataEternalStorage;
+        addressStorage[REWARD_BY_BLOCK_ETERNAL_STORAGE] = 
+            _rewardByBlockEternalStorage;
         boolStorage[MOC_INITIALIZED] = true;
         emit ProxyInitialized(
             _keysManagerEternalStorage,
             _votingToChangeKeysEternalStorage,
             _votingToChangeMinThresholdEternalStorage,
             _votingToChangeProxyEternalStorage,
+            _votingToManageEmissionFundsEternalStorage,
             _ballotsStorageEternalStorage,
-            _validatorMetadataEternalStorage
+            _validatorMetadataEternalStorage,
+            _rewardByBlockEternalStorage
         );
     }
 

--- a/contracts/interfaces/IProxyStorage.sol
+++ b/contracts/interfaces/IProxyStorage.sol
@@ -2,7 +2,9 @@ pragma solidity ^0.4.24;
 
 
 interface IProxyStorage {
-    function initializeAddresses(address, address, address, address, address, address) external;
+    function initializeAddresses(
+        address, address, address, address, address, address, address, address
+    ) external;
     function setContractAddress(uint256, address) external;
     function isValidator(address) external view returns(bool);
     function getBallotsStorage() external view returns(address);

--- a/scripts/migrate/migrateAll.js
+++ b/scripts/migrate/migrateAll.js
@@ -239,8 +239,10 @@ async function main() {
 			votingToChangeKeysNewAddress,
 			votingToChangeMinThresholdNewAddress,
 			votingToChangeProxyNewAddress,
+			votingToManageEmissionFundsAddress,
 			ballotsStorageNewAddress,
-			process.env.METADATA_NEW_ADDRESS
+			process.env.METADATA_NEW_ADDRESS,
+			rewardByBlockAddress
 		);
 		await utils.call(initializeAddresses, sender, process.env.PROXY_STORAGE_NEW_ADDRESS, key, chainId);
 		true.should.be.equal(

--- a/test/ballots_storage_test.js
+++ b/test/ballots_storage_test.js
@@ -18,13 +18,17 @@ contract('BallotsStorage [all features]', function (accounts) {
     votingToChangeKeys,
     votingToChangeMinThreshold,
     votingToChangeProxy,
-    validatorMetadataEternalStorage
+    votingToManageEmissionFunds,
+    validatorMetadataEternalStorage,
+    rewardByBlock
   } = {
     keysManager: '',
     votingToChangeKeys: accounts[0],
     votingToChangeMinThreshold: accounts[3],
     votingToChangeProxy: accounts[4],
-    validatorMetadataEternalStorage: accounts[7]
+    votingToManageEmissionFunds: accounts[5],
+    validatorMetadataEternalStorage: accounts[7],
+    rewardByBlock: accounts[8]
   }
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
@@ -54,8 +58,10 @@ contract('BallotsStorage [all features]', function (accounts) {
       votingToChangeKeys,
       votingToChangeMinThreshold,
       votingToChangeProxy,
+      votingToManageEmissionFunds,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage
+      validatorMetadataEternalStorage,
+      rewardByBlock
     );
   })
   

--- a/test/ballots_storage_upgrade_test.js
+++ b/test/ballots_storage_upgrade_test.js
@@ -18,13 +18,17 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
     votingToChangeKeys,
     votingToChangeMinThreshold,
     votingToChangeProxy,
-    validatorMetadataEternalStorage
+    votingToManageEmissionFunds,
+    validatorMetadataEternalStorage,
+    rewardByBlock
   } = {
     keysManager: '',
     votingToChangeKeys: accounts[0],
     votingToChangeMinThreshold: accounts[3],
     votingToChangeProxy: accounts[4],
-    validatorMetadataEternalStorage: accounts[7]
+    votingToManageEmissionFunds: accounts[5],
+    validatorMetadataEternalStorage: accounts[7],
+    rewardByBlock: accounts[8]
   }
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
@@ -54,8 +58,10 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
       votingToChangeKeys,
       votingToChangeMinThreshold,
       votingToChangeProxy,
+      votingToManageEmissionFunds,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage
+      validatorMetadataEternalStorage,
+      rewardByBlock
     );
 
     let ballotsStorageNew = await BallotsStorageNew.new();

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -41,6 +41,8 @@ contract('KeysManager [all features]', function (accounts) {
       accounts[0],
       accounts[0],
       accounts[0],
+      accounts[0],
+      accounts[0],
       accounts[0]
     );
   });

--- a/test/keys_manager_upgrade_test.js
+++ b/test/keys_manager_upgrade_test.js
@@ -47,6 +47,8 @@ contract('KeysManager upgraded [all features]', function (accounts) {
       accounts[0],
       accounts[0],
       accounts[0],
+      accounts[0],
+      accounts[0],
       accounts[0]
     );
   });

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -66,11 +66,13 @@ contract('ValidatorMetadata [all features]', function (accounts) {
     
     await proxyStorageMock.initializeAddresses(
       keysManager.address,
-      masterOfCeremony,
-      masterOfCeremony,
-      masterOfCeremony,
+      accounts[0],
+      accounts[0],
+      accounts[0],
+      accounts[0],
       ballotsEternalStorage.address,
-      metadataEternalStorage.address
+      metadataEternalStorage.address,
+      accounts[0]
     );
     
     metadata = await ValidatorMetadata.at(metadataEternalStorage.address);

--- a/test/metadata_upgrade_test.js
+++ b/test/metadata_upgrade_test.js
@@ -66,11 +66,13 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
     
     await proxyStorageMock.initializeAddresses(
       keysManager.address,
-      masterOfCeremony,
-      masterOfCeremony,
-      masterOfCeremony,
+      accounts[0],
+      accounts[0],
+      accounts[0],
+      accounts[0],
       ballotsEternalStorage.address,
-      metadataEternalStorage.address
+      metadataEternalStorage.address,
+      accounts[0]
     );
 
     let metadataNew = await ValidatorMetadataNew.new();

--- a/test/poa_network_consensus_test.js
+++ b/test/poa_network_consensus_test.js
@@ -29,6 +29,8 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
       accounts[0],
       accounts[0],
       accounts[0],
+      accounts[0],
+      accounts[0],
       accounts[0]
     );
   });

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -7,6 +7,8 @@ let BallotsStorage = artifacts.require('./BallotsStorage');
 let VotingToChangeKeys = artifacts.require('./VotingToChangeKeys');
 let VotingToChangeMinThreshold = artifacts.require('./VotingToChangeMinThreshold');
 let VotingToChangeProxy = artifacts.require('./VotingToChangeProxyAddress');
+let VotingToManageEmissionFunds = artifacts.require('./VotingToManageEmissionFunds');
+let RewardByBlock = artifacts.require('./RewardByBlock');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 require('chai')
@@ -22,6 +24,8 @@ let ballotsStorage, ballotsEternalStorage;
 let votingToChangeKeys, votingToChangeKeysEternalStorage;
 let votingToChangeMinThreshold, votingToChangeMinThresholdEternalStorage;
 let votingToChangeProxy, votingToChangeProxyEternalStorage;
+let votingToManageEmissionFunds, votingToManageEmissionFundsEternalStorage;
+let rewardByBlock, rewardByBlockEternalStorage;
 contract('ProxyStorage [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
@@ -53,6 +57,12 @@ contract('ProxyStorage [all features]', function (accounts) {
 
     votingToChangeProxy = await VotingToChangeProxy.new();
     votingToChangeProxyEternalStorage = await EternalStorageProxy.new(proxyStorage.address, votingToChangeProxy.address);
+
+    votingToManageEmissionFunds = await VotingToManageEmissionFunds.new();
+    votingToManageEmissionFundsEternalStorage = await EternalStorageProxy.new(proxyStorage.address, votingToManageEmissionFunds.address);
+
+    rewardByBlock = await RewardByBlock.new();
+    rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorage.address, rewardByBlock.address);
   })
   describe('#constructor', async () => {
     it('sets MoC and Poa', async () => {
@@ -71,8 +81,10 @@ contract('ProxyStorage [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
         validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address,
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
       const {logs} = await proxyStorage.initializeAddresses(
@@ -80,8 +92,10 @@ contract('ProxyStorage [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
         validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address
       ).should.be.fulfilled;
       keysManagerEternalStorage.address.should.be.equal(
         await proxyStorage.getKeysManager.call()
@@ -95,19 +109,27 @@ contract('ProxyStorage [all features]', function (accounts) {
       votingToChangeProxyEternalStorage.address.should.be.equal(
         await proxyStorage.getVotingToChangeProxy.call()
       );
+      votingToManageEmissionFundsEternalStorage.address.should.be.equal(
+        await proxyStorage.getVotingToManageEmissionFunds.call()
+      );
       ballotsEternalStorage.address.should.be.equal(
         await proxyStorage.getBallotsStorage.call()
       );
       validatorMetadataEternalStorage.address.should.be.equal(
         await proxyStorage.getValidatorMetadata.call()
       );
+      rewardByBlockEternalStorage.address.should.be.equal(
+        await proxyStorage.getRewardByBlock.call()
+      );
       logs[0].event.should.be.equal('ProxyInitialized');
       logs[0].args.keysManagerEternalStorage.should.be.equal(keysManagerEternalStorage.address);
       logs[0].args.votingToChangeKeysEternalStorage.should.be.equal(votingToChangeKeysEternalStorage.address);
       logs[0].args.votingToChangeMinThresholdEternalStorage.should.be.equal(votingToChangeMinThresholdEternalStorage.address);
       logs[0].args.votingToChangeProxyEternalStorage.should.be.equal(votingToChangeProxyEternalStorage.address);
+      logs[0].args.votingToManageEmissionFundsEternalStorage.should.be.equal(votingToManageEmissionFundsEternalStorage.address);
       logs[0].args.ballotsStorageEternalStorage.should.be.equal(ballotsEternalStorage.address);
       logs[0].args.validatorMetadataEternalStorage.should.be.equal(validatorMetadataEternalStorage.address);
+      logs[0].args.rewardByBlockEternalStorage.should.be.equal(rewardByBlockEternalStorage.address);
     })
     it('prevents Moc to call it more than once', async () => {
       false.should.be.equal(await proxyStorage.mocInitialized.call());
@@ -116,8 +138,10 @@ contract('ProxyStorage [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
-        validatorMetadataEternalStorage.address
+        validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address
       ).should.be.fulfilled;
       true.should.be.equal(await proxyStorage.mocInitialized.call());
       await proxyStorage.initializeAddresses(
@@ -125,8 +149,10 @@ contract('ProxyStorage [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
-        validatorMetadataEternalStorage.address
+        validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address
       ).should.be.rejectedWith(ERROR_MSG);
     })
   })
@@ -138,8 +164,10 @@ contract('ProxyStorage [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
         validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address,
         {from: masterOfCeremony}
       ).should.be.fulfilled;
     })

--- a/test/proxy_storage_upgrade_test.js
+++ b/test/proxy_storage_upgrade_test.js
@@ -7,6 +7,8 @@ let BallotsStorage = artifacts.require('./BallotsStorage');
 let VotingToChangeKeys = artifacts.require('./VotingToChangeKeys');
 let VotingToChangeMinThreshold = artifacts.require('./VotingToChangeMinThreshold');
 let VotingToChangeProxy = artifacts.require('./VotingToChangeProxyAddress');
+let VotingToManageEmissionFunds = artifacts.require('./VotingToManageEmissionFunds');
+let RewardByBlock = artifacts.require('./RewardByBlock');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 require('chai')
@@ -22,6 +24,8 @@ let ballotsStorage, ballotsEternalStorage;
 let votingToChangeKeys, votingToChangeKeysEternalStorage;
 let votingToChangeMinThreshold, votingToChangeMinThresholdEternalStorage;
 let votingToChangeProxy, votingToChangeProxyEternalStorage;
+let votingToManageEmissionFunds, votingToManageEmissionFundsEternalStorage;
+let rewardByBlock, rewardByBlockEternalStorage;
 contract('ProxyStorage upgraded [all features]', function (accounts) {
   masterOfCeremony = accounts[0];
   beforeEach(async () => {
@@ -59,6 +63,12 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
 
     votingToChangeProxy = await VotingToChangeProxy.new();
     votingToChangeProxyEternalStorage = await EternalStorageProxy.new(proxyStorage.address, votingToChangeProxy.address);
+
+    votingToManageEmissionFunds = await VotingToManageEmissionFunds.new();
+    votingToManageEmissionFundsEternalStorage = await EternalStorageProxy.new(proxyStorage.address, votingToManageEmissionFunds.address);
+
+    rewardByBlock = await RewardByBlock.new();
+    rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorage.address, rewardByBlock.address);
   })
   describe('#constructor', async () => {
     it('sets MoC and Poa', async () => {
@@ -77,8 +87,10 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
         validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address,
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
       const {logs} = await proxyStorage.initializeAddresses(
@@ -86,8 +98,10 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
         validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address
       ).should.be.fulfilled;
       keysManagerEternalStorage.address.should.be.equal(
         await proxyStorage.getKeysManager.call()
@@ -101,19 +115,27 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
       votingToChangeProxyEternalStorage.address.should.be.equal(
         await proxyStorage.getVotingToChangeProxy.call()
       );
+      votingToManageEmissionFundsEternalStorage.address.should.be.equal(
+        await proxyStorage.getVotingToManageEmissionFunds.call()
+      );
       ballotsEternalStorage.address.should.be.equal(
         await proxyStorage.getBallotsStorage.call()
       );
       validatorMetadataEternalStorage.address.should.be.equal(
         await proxyStorage.getValidatorMetadata.call()
       );
+      rewardByBlockEternalStorage.address.should.be.equal(
+        await proxyStorage.getRewardByBlock.call()
+      );
       logs[0].event.should.be.equal('ProxyInitialized');
       logs[0].args.keysManagerEternalStorage.should.be.equal(keysManagerEternalStorage.address);
       logs[0].args.votingToChangeKeysEternalStorage.should.be.equal(votingToChangeKeysEternalStorage.address);
       logs[0].args.votingToChangeMinThresholdEternalStorage.should.be.equal(votingToChangeMinThresholdEternalStorage.address);
       logs[0].args.votingToChangeProxyEternalStorage.should.be.equal(votingToChangeProxyEternalStorage.address);
+      logs[0].args.votingToManageEmissionFundsEternalStorage.should.be.equal(votingToManageEmissionFundsEternalStorage.address);
       logs[0].args.ballotsStorageEternalStorage.should.be.equal(ballotsEternalStorage.address);
       logs[0].args.validatorMetadataEternalStorage.should.be.equal(validatorMetadataEternalStorage.address);
+      logs[0].args.rewardByBlockEternalStorage.should.be.equal(rewardByBlockEternalStorage.address);
     })
     it('prevents Moc to call it more than once', async () => {
       false.should.be.equal(await proxyStorage.mocInitialized.call());
@@ -122,8 +144,10 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
-        validatorMetadataEternalStorage.address
+        validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address
       ).should.be.fulfilled;
       true.should.be.equal(await proxyStorage.mocInitialized.call());
       await proxyStorage.initializeAddresses(
@@ -131,8 +155,10 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
-        validatorMetadataEternalStorage.address
+        validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address
       ).should.be.rejectedWith(ERROR_MSG);
     })
   })
@@ -144,8 +170,10 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
         votingToChangeKeysEternalStorage.address,
         votingToChangeMinThresholdEternalStorage.address,
         votingToChangeProxyEternalStorage.address,
+        votingToManageEmissionFundsEternalStorage.address,
         ballotsEternalStorage.address,
         validatorMetadataEternalStorage.address,
+        rewardByBlockEternalStorage.address,
         {from: masterOfCeremony}
       ).should.be.fulfilled;
     })

--- a/test/reward_by_block_test.js
+++ b/test/reward_by_block_test.js
@@ -51,6 +51,8 @@ contract('RewardByBlock [all features]', function (accounts) {
       accounts[9],
       accounts[9],
       accounts[9],
+      accounts[9],
+      accounts[9],
       accounts[9]
     );
 

--- a/test/reward_by_block_upgrade_test.js
+++ b/test/reward_by_block_upgrade_test.js
@@ -51,6 +51,8 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
       accounts[9],
       accounts[9],
       accounts[9],
+      accounts[9],
+      accounts[9],
       accounts[9]
     );
 

--- a/test/reward_by_time_test.js
+++ b/test/reward_by_time_test.js
@@ -52,6 +52,8 @@ contract('RewardByTime [all features]', function (accounts) {
       accounts[9],
       accounts[9],
       accounts[9],
+      accounts[9],
+      accounts[9],
       accounts[9]
     );
 

--- a/test/reward_by_time_upgrade_test.js
+++ b/test/reward_by_time_upgrade_test.js
@@ -52,6 +52,8 @@ contract('RewardByTime [all features]', function (accounts) {
       accounts[9],
       accounts[9],
       accounts[9],
+      accounts[9],
+      accounts[9],
       accounts[9]
     );
 

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -51,10 +51,12 @@ contract('Voting to change keys [all features]', function (accounts) {
     await proxyStorageMock.initializeAddresses(
       keysManagerEternalStorage.address,
       votingEternalStorage.address,
-      masterOfCeremony,
-      masterOfCeremony,
+      accounts[0],
+      accounts[0],
+      accounts[0],
       ballotsEternalStorage.address,
-      masterOfCeremony
+      accounts[0],
+      accounts[0]
     );
 
     ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);

--- a/test/voting_to_change_keys_upgrade_test.js
+++ b/test/voting_to_change_keys_upgrade_test.js
@@ -53,10 +53,12 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
     await proxyStorageMock.initializeAddresses(
       keysManagerEternalStorage.address,
       votingEternalStorage.address,
-      masterOfCeremony,
-      masterOfCeremony,
+      accounts[0],
+      accounts[0],
+      accounts[0],
       ballotsEternalStorage.address,
-      masterOfCeremony
+      accounts[0],
+      accounts[0]
     );
 
     await ballotsStorage.init([3, 2]).should.be.fulfilled;

--- a/test/voting_to_change_min_threshold_test.js
+++ b/test/voting_to_change_min_threshold_test.js
@@ -57,11 +57,13 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
     
     await proxyStorageMock.initializeAddresses(
       keysManager.address,
-      masterOfCeremony,
+      accounts[0],
       voting.address,
-      masterOfCeremony,
+      accounts[0],
+      accounts[0],
       ballotsEternalStorage.address,
-      masterOfCeremony
+      accounts[0],
+      accounts[0]
     );
     
     ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);

--- a/test/voting_to_change_min_threshold_upgrade_test.js
+++ b/test/voting_to_change_min_threshold_upgrade_test.js
@@ -63,11 +63,13 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     
     await proxyStorageMock.initializeAddresses(
       keysManager.address,
-      masterOfCeremony,
+      accounts[0],
       voting.address,
-      masterOfCeremony,
+      accounts[0],
+      accounts[0],
       ballotsEternalStorage.address,
-      masterOfCeremony
+      accounts[0],
+      accounts[0]
     );
     
     ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -5,8 +5,10 @@ let VotingToChangeProxyAddress = artifacts.require('./mockContracts/VotingToChan
 let VotingToChangeProxyAddressNew = artifacts.require('./upgradeContracts/VotingToChangeProxyAddressNew');
 let VotingForKeys = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 let VotingForMinThreshold = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
+let VotingForEmissionFunds = artifacts.require('./mockContracts/VotingToManageEmissionFundsMock');
 let BallotsStorage = artifacts.require('./BallotsStorage');
 let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
+let RewardByBlock = artifacts.require('./RewardByBlock');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const moment = require('moment');
@@ -61,6 +63,10 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
     const votingForMinThresholdEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingForMinThreshold.address);
     votingForMinThreshold = await VotingForMinThreshold.at(votingForMinThresholdEternalStorage.address);
     await votingForMinThreshold.init(172800, 3).should.be.fulfilled;
+
+    let votingForEmissionFunds = await VotingForEmissionFunds.new();
+    const votingForEmissionFundsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingForEmissionFunds.address);
+    votingForEmissionFunds = await VotingForEmissionFunds.at(votingForEmissionFundsEternalStorage.address);
     
     voting = await VotingToChangeProxyAddress.new();
     const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
@@ -71,13 +77,19 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
     const validatorMetadata = await ValidatorMetadata.new();
     const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
 
+    let rewardByBlock = await RewardByBlock.new();
+    const rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, rewardByBlock.address);
+    rewardByBlock = await RewardByBlock.at(rewardByBlockEternalStorage.address);
+
     await proxyStorageMock.initializeAddresses(
       keysManagerEternalStorage.address,
       votingForKeysEternalStorage.address,
       votingForMinThresholdEternalStorage.address,
       votingEternalStorage.address,
+      votingForEmissionFunds.address,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage.address
+      validatorMetadataEternalStorage.address,
+      rewardByBlock.address
     );
   })
 

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -5,8 +5,10 @@ let VotingToChangeProxyAddress = artifacts.require('./mockContracts/VotingToChan
 let VotingToChangeProxyAddressNew = artifacts.require('./upgradeContracts/VotingToChangeProxyAddressNew');
 let VotingForKeys = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 let VotingForMinThreshold = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
+let VotingForEmissionFunds = artifacts.require('./mockContracts/VotingToManageEmissionFundsMock');
 let BallotsStorage = artifacts.require('./BallotsStorage');
 let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
+let RewardByBlock = artifacts.require('./RewardByBlock');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const moment = require('moment');
@@ -61,6 +63,10 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
     const votingForMinThresholdEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingForMinThreshold.address);
     votingForMinThreshold = await VotingForMinThreshold.at(votingForMinThresholdEternalStorage.address);
     await votingForMinThreshold.init(172800, 3).should.be.fulfilled;
+
+    let votingForEmissionFunds = await VotingForEmissionFunds.new();
+    const votingForEmissionFundsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingForEmissionFunds.address);
+    votingForEmissionFunds = await VotingForEmissionFunds.at(votingForEmissionFundsEternalStorage.address);
     
     voting = await VotingToChangeProxyAddress.new();
     const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
@@ -77,13 +83,19 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
     const validatorMetadata = await ValidatorMetadata.new();
     const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
 
+    let rewardByBlock = await RewardByBlock.new();
+    const rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, rewardByBlock.address);
+    rewardByBlock = await RewardByBlock.at(rewardByBlockEternalStorage.address);
+
     await proxyStorageMock.initializeAddresses(
       keysManagerEternalStorage.address,
       votingForKeysEternalStorage.address,
       votingForMinThresholdEternalStorage.address,
       votingEternalStorage.address,
+      votingForEmissionFunds.address,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage.address
+      validatorMetadataEternalStorage.address,
+      rewardByBlock.address
     );
   })
 

--- a/test/voting_to_manage_emission_funds_test.js
+++ b/test/voting_to_manage_emission_funds_test.js
@@ -4,6 +4,7 @@ const EternalStorageProxy = artifacts.require('./mockContracts/EternalStoragePro
 const KeysManager = artifacts.require('./mockContracts/KeysManagerMock');
 const PoaNetworkConsensus = artifacts.require('./mockContracts/PoaNetworkConsensusMock');
 const ProxyStorage = artifacts.require('./mockContracts/ProxyStorageMock');
+const RewardByBlock = artifacts.require('./mockContracts/RewardByBlockMock');
 const ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 const VotingForKeys = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 const VotingForMinThreshold = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
@@ -104,14 +105,20 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       emissionReleaseThreshold,
       distributionThreshold
     ).should.be.fulfilled;
+
+    rewardByBlock = await RewardByBlock.new();
+    const rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorage.address, rewardByBlock.address);
+    rewardByBlock = await RewardByBlock.at(rewardByBlockEternalStorage.address);
     
     await proxyStorage.initializeAddresses(
       keysManagerEternalStorage.address,
       votingForKeysEternalStorage.address,
       votingForMinThresholdEternalStorage.address,
       votingForProxyEternalStorage.address,
+      votingEternalStorage.address,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage.address
+      validatorMetadataEternalStorage.address,
+      rewardByBlockEternalStorage.address
     );
 
     (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(0);

--- a/test/voting_to_manage_emission_funds_upgrade_test.js
+++ b/test/voting_to_manage_emission_funds_upgrade_test.js
@@ -4,6 +4,7 @@ const EternalStorageProxy = artifacts.require('./mockContracts/EternalStoragePro
 const KeysManager = artifacts.require('./mockContracts/KeysManagerMock');
 const PoaNetworkConsensus = artifacts.require('./mockContracts/PoaNetworkConsensusMock');
 const ProxyStorage = artifacts.require('./mockContracts/ProxyStorageMock');
+const RewardByBlock = artifacts.require('./mockContracts/RewardByBlockMock');
 const ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 const VotingForKeys = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 const VotingForMinThreshold = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
@@ -104,14 +105,20 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       emissionReleaseThreshold,
       distributionThreshold
     ).should.be.fulfilled;
+
+    rewardByBlock = await RewardByBlock.new();
+    const rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorage.address, rewardByBlock.address);
+    rewardByBlock = await RewardByBlock.at(rewardByBlockEternalStorage.address);
     
     await proxyStorage.initializeAddresses(
       keysManagerEternalStorage.address,
       votingForKeysEternalStorage.address,
       votingForMinThresholdEternalStorage.address,
       votingForProxyEternalStorage.address,
+      votingEternalStorage.address,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage.address
+      validatorMetadataEternalStorage.address,
+      rewardByBlockEternalStorage.address
     );
 
     (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(0);


### PR DESCRIPTION
- (Mandatory) Description
`ProxyStorage` contract has been supplemented to be able to store the addresses of `RewardByBlock` and `VotingToManageEmissionFunds` contracts (addresses of their eternal storages) which contain logic described for `Increased Emission Supply` in https://github.com/poanetwork/RFC/issues/14. However, `ProxyStorage.setContractAddress` function still doesn't allow to change implementations of these contracts because it is supposed to add this feature later, when necessary, by upgrading ProxyStorage's implementation (validators will be able to do that with `VotingToChangeProxyAddress`).

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Fix)