### PR TITLE
(Fix) KeysManager.sol and VotingToChange.sol

### DIFF
--- a/contracts/abstracts/VotingToChange.sol
+++ b/contracts/abstracts/VotingToChange.sol
@@ -223,7 +223,10 @@ contract VotingToChange is IVotingToChange, VotingTo {
 
     function _decreaseValidatorLimit(uint256 _id) internal {
         address miningKey = getCreator(_id);
-        _setValidatorActiveBallots(miningKey, validatorActiveBallots(miningKey).sub(1));
+        uint256 ballotsCount = validatorActiveBallots(miningKey);
+        if (ballotsCount > 0) {
+            _setValidatorActiveBallots(miningKey, ballotsCount - 1);
+        }
     }
 
     function _finalizeBallot(uint256 _id) internal {

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -411,6 +411,7 @@ contract('KeysManager [all features]', function (accounts) {
       );
       const result = await keysManager.removeVotingKey(accounts[1]).should.be.fulfilled;
       result.logs.length.should.be.equal(0);
+      await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
     })
   
     it('removes validator from poaConsensus', async () => {
@@ -468,10 +469,14 @@ contract('KeysManager [all features]', function (accounts) {
     });
 
     it('should still enforce removal of votingKey to 0x0 even if voting key did not exist', async () => {
-      await keysManager.removeMiningKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      let result = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      result.logs.length.should.be.equal(0);
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      const {logs} = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      result = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      result.logs[0].event.should.be.equal('MiningKeyChanged');
+      result.logs[0].args.key.should.be.equal(accounts[1]);
+      result.logs[0].args.action.should.be.equal('removed');
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       (await keysManager.getMiningKeyByVoting.call(validator[0])).should.be.equal(
         '0x0000000000000000000000000000000000000000'

--- a/test/keys_manager_upgrade_test.js
+++ b/test/keys_manager_upgrade_test.js
@@ -417,6 +417,7 @@ contract('KeysManager upgraded [all features]', function (accounts) {
       );
       const result = await keysManager.removeVotingKey(accounts[1]).should.be.fulfilled;
       result.logs.length.should.be.equal(0);
+      await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
     })
   
     it('removes validator from poaConsensus', async () => {
@@ -474,10 +475,14 @@ contract('KeysManager upgraded [all features]', function (accounts) {
     });
 
     it('should still enforce removal of votingKey to 0x0 even if voting key did not exist', async () => {
-      await keysManager.removeMiningKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      let result = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      result.logs.length.should.be.equal(0);
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      const {logs} = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      result = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      result.logs[0].event.should.be.equal('MiningKeyChanged');
+      result.logs[0].args.key.should.be.equal(accounts[1]);
+      result.logs[0].args.action.should.be.equal('removed');
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       (await keysManager.getMiningKeyByVoting.call(validator[0])).should.be.equal(
         '0x0000000000000000000000000000000000000000'

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -1107,21 +1107,51 @@ async function deployAndTestBallot({_affectedKey, _affectedKeyType, _miningKey, 
     _miningKey,
     _ballotType,
     "memo",
-     {from: votingKey});
-  const activeBallotsLength = await voting.activeBallotsLength.call();
+    {from: votingKey}
+  );
+
   new web3.BigNumber(_ballotType).should.be.bignumber.equal(await voting.getBallotType.call(votingId));
   await voting.setTime(VOTING_START_DATE);
   await voting.vote(votingId, choice.reject, {from: votingKey}).should.be.fulfilled;
   false.should.be.equal(await voting.hasAlreadyVoted.call(votingId, votingKey2));
   await voting.vote(votingId, choice.accept, {from: votingKey2}).should.be.fulfilled;
   await voting.vote(votingId, choice.accept, {from: votingKey3}).should.be.fulfilled;
-
   (await voting.getTotalVoters.call(votingId)).should.be.bignumber.equal(3);
   false.should.be.equal(await voting.getIsFinalized.call(votingId));
+
+  let secondVotingId = null;
+  if (_affectedKeyType == 1 && _ballotType == 2) { // mining key removal
+    // create a new ballot to remove the same mining key
+    secondVotingId = votingId + 1;
+    await voting.createBallot(
+      VOTING_START_DATE+10,
+      VOTING_END_DATE,
+      _affectedKey,
+      _affectedKeyType,
+      _miningKey,
+      _ballotType,
+      "memo",
+      {from: votingKey}
+    );
+    new web3.BigNumber(_ballotType).should.be.bignumber.equal(await voting.getBallotType.call(secondVotingId));
+    await voting.setTime(VOTING_START_DATE+10);
+    await voting.vote(secondVotingId, choice.reject, {from: votingKey}).should.be.fulfilled;
+    false.should.be.equal(await voting.hasAlreadyVoted.call(secondVotingId, votingKey2));
+    await voting.vote(secondVotingId, choice.accept, {from: votingKey2}).should.be.fulfilled;
+    await voting.vote(secondVotingId, choice.accept, {from: votingKey3}).should.be.fulfilled;
+    (await voting.getTotalVoters.call(secondVotingId)).should.be.bignumber.equal(3);
+    false.should.be.equal(await voting.getIsFinalized.call(secondVotingId));
+  }
+
   await voting.setTime(VOTING_END_DATE + 1);
   const {logs} = await voting.finalize(votingId, {from: votingKey}).should.be.fulfilled;
   true.should.be.equal(await voting.getIsFinalized.call(votingId));
-  
+
+  if (secondVotingId !== null) {
+    await voting.finalize(secondVotingId, {from: votingKey}).should.be.fulfilled;
+    true.should.be.equal(await voting.getIsFinalized.call(secondVotingId));
+  }
+
   (await voting.getStartTime.call(votingId)).should.be.bignumber.equal(VOTING_START_DATE);
   (await voting.getEndTime.call(votingId)).should.be.bignumber.equal(VOTING_END_DATE);
   (await voting.getAffectedKey.call(votingId)).should.be.equal(_affectedKey);


### PR DESCRIPTION
- (Mandatory) Description
These changes fix minor issues with `KeysManager` contract and `VotingToChange` abstract contract. Now, ballot for removing mining key can be finalized even if mining key is already removed. Also, `VotingToChange._decreaseValidatorLimit` now doesn't revert if the number of validator's active ballots is zero. The changes are covered with unit tests.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Fix)