### PR TITLE
(Fix) Don't allow adding voting/ payout key for zero mining key

### DIFF
--- a/contracts/VotingToChangeKeys.sol
+++ b/contracts/VotingToChangeKeys.sol
@@ -232,10 +232,10 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange {
         }
         if (_affectedKeyType == uint256(KeyTypes.VotingKey)) {
             require(_miningKey != IKeysManager(getKeysManager()).masterOfCeremony());
-            return _affectedKey != _miningKey;
+            return _affectedKey != _miningKey && _miningKey != address(0);
         }
         if (_affectedKeyType == uint256(KeyTypes.PayoutKey)) {
-            return _affectedKey != _miningKey;
+            return _affectedKey != _miningKey && _miningKey != address(0);
         }
     }
 

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -142,6 +142,28 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, masterOfCeremony, 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
       await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
     })
+    it('should not let add votingKey for 0x0', async () => {
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+      await keysManager.addMiningKey(accounts[2]).should.be.fulfilled;
+      await proxyStorageMock.setVotingContractMock(voting.address);
+      VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
+      VOTING_END_DATE = moment.utc().add(10, 'days').unix();
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+    })
+    it('should not let add payoutKey for 0x0', async () => {
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+      await keysManager.addMiningKey(accounts[2]).should.be.fulfilled;
+      await proxyStorageMock.setVotingContractMock(voting.address);
+      VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
+      VOTING_END_DATE = moment.utc().add(10, 'days').unix();
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+    })
     it('should not let create more ballots than the limit', async () => {
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;

--- a/test/voting_to_change_keys_upgrade_test.js
+++ b/test/voting_to_change_keys_upgrade_test.js
@@ -147,6 +147,28 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, masterOfCeremony, 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
       await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
     })
+    it('should not let add votingKey for 0x0', async () => {
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+      await keysManager.addMiningKey(accounts[2]).should.be.fulfilled;
+      await proxyStorageMock.setVotingContractMock(voting.address);
+      VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
+      VOTING_END_DATE = moment.utc().add(10, 'days').unix();
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+    })
+    it('should not let add payoutKey for 0x0', async () => {
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
+      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+      await keysManager.addMiningKey(accounts[2]).should.be.fulfilled;
+      await proxyStorageMock.setVotingContractMock(voting.address);
+      VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
+      VOTING_END_DATE = moment.utc().add(10, 'days').unix();
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+    })
     it('should not let create more ballots than the limit', async () => {
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
       await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;


### PR DESCRIPTION
- (Mandatory) Description
`VotingToChangeKeys` contract allows creating a ballot for adding voting/ payout key with 0x0 mining key (see `VotingToChangeKey.areBallotParamsValid` function). Corresponding issue: https://github.com/poanetwork/poa-dapps-voting/issues/161. This PR fixes that.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)