### PR TITLE
(Refactor) Add KeysManager.getInitialKeyStatus function instead of initialKeys and getInitialKey

### DIFF
--- a/contracts/interfaces/IKeysManager.sol
+++ b/contracts/interfaces/IKeysManager.sol
@@ -24,8 +24,13 @@ interface IKeysManager {
     function getTime() external view returns(uint256);
     function getMiningKeyHistory(address) external view returns(address);
     function getMiningKeyByVoting(address) external view returns(address);
-    function getInitialKey(address) external view returns(uint8);
+    function getInitialKeyStatus(address) external view returns(uint8);
     function masterOfCeremony() external view returns(address);
     function miningKeyByPayout(address) external view returns(address);
     function miningKeyByVoting(address) external view returns(address);
+}
+
+
+interface IKeysManagerPrev {
+    function getInitialKey(address) external view returns(uint8);
 }

--- a/scripts/migrate/migrateKeys.js
+++ b/scripts/migrate/migrateKeys.js
@@ -167,7 +167,7 @@ async function migrateAndCheck(privateKey) {
 		for (let i = 0; i < initialKeys.length; i++) {
 			const initialKey = initialKeys[i];
 			(await keysManagerOldInstance.methods.getInitialKey(initialKey).call()).should.be.equal(
-				await keysManagerNewInstance.methods.getInitialKey(initialKey).call()
+				await keysManagerNewInstance.methods.getInitialKeyStatus(initialKey).call()
 			);
 		}
 		for (let i = 0; i < miningKeys.length; i++) {

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -123,9 +123,9 @@ contract('KeysManager [all features]', function (accounts) {
     })
 
     it('should set initialKeys hash to activated status', async() => {
-      new web3.BigNumber(0).should.be.bignumber.equal(await keysManager.initialKeys.call(accounts[1]));
+      new web3.BigNumber(0).should.be.bignumber.equal(await keysManager.getInitialKeyStatus.call(accounts[1]));
       const {logs} = await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
-      new web3.BigNumber(1).should.be.bignumber.equal(await keysManager.initialKeys.call(accounts[1]));
+      new web3.BigNumber(1).should.be.bignumber.equal(await keysManager.getInitialKeyStatus.call(accounts[1]));
       let initialKeysCount = await keysManager.initialKeysCount.call();
       // event InitialKeyCreated(address indexed initialKey, uint256 time, uint256 initialKeysCount);
       logs[0].event.should.equal("InitialKeyCreated");
@@ -243,7 +243,7 @@ contract('KeysManager [all features]', function (accounts) {
       let miningKey = accounts[4];
       await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
       await keysManager.createKeys(miningKey, accounts[3], accounts[2], {from: accounts[1]});
-      new web3.BigNumber(2).should.be.bignumber.equal(await keysManager.initialKeys.call(accounts[1]));
+      new web3.BigNumber(2).should.be.bignumber.equal(await keysManager.getInitialKeyStatus.call(accounts[1]));
     })
   })
 
@@ -717,11 +717,11 @@ contract('KeysManager [all features]', function (accounts) {
       await newKeysManager.migrateInitialKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
 
       new web3.BigNumber(1).should.be.bignumber.equal(
-        await newKeysManager.initialKeys.call(accounts[1])
+        await newKeysManager.getInitialKeyStatus.call(accounts[1])
       )
       await newKeysManager.migrateInitialKey(accounts[2]).should.be.rejectedWith(ERROR_MSG);
       new web3.BigNumber(0).should.be.bignumber.equal(
-        await newKeysManager.initialKeys.call(accounts[2])
+        await newKeysManager.getInitialKeyStatus.call(accounts[2])
       )
     })
   });

--- a/test/keys_manager_upgrade_test.js
+++ b/test/keys_manager_upgrade_test.js
@@ -129,9 +129,9 @@ contract('KeysManager upgraded [all features]', function (accounts) {
     })
 
     it('should set initialKeys hash to activated status', async() => {
-      new web3.BigNumber(0).should.be.bignumber.equal(await keysManager.initialKeys.call(accounts[1]));
+      new web3.BigNumber(0).should.be.bignumber.equal(await keysManager.getInitialKeyStatus.call(accounts[1]));
       const {logs} = await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
-      new web3.BigNumber(1).should.be.bignumber.equal(await keysManager.initialKeys.call(accounts[1]));
+      new web3.BigNumber(1).should.be.bignumber.equal(await keysManager.getInitialKeyStatus.call(accounts[1]));
       let initialKeysCount = await keysManager.initialKeysCount.call();
       // event InitialKeyCreated(address indexed initialKey, uint256 time, uint256 initialKeysCount);
       logs[0].event.should.equal("InitialKeyCreated");
@@ -249,7 +249,7 @@ contract('KeysManager upgraded [all features]', function (accounts) {
       let miningKey = accounts[4];
       await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
       await keysManager.createKeys(miningKey, accounts[3], accounts[2], {from: accounts[1]});
-      new web3.BigNumber(2).should.be.bignumber.equal(await keysManager.initialKeys.call(accounts[1]));
+      new web3.BigNumber(2).should.be.bignumber.equal(await keysManager.getInitialKeyStatus.call(accounts[1]));
     })
   })
 
@@ -723,11 +723,11 @@ contract('KeysManager upgraded [all features]', function (accounts) {
       await newKeysManager.migrateInitialKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
 
       new web3.BigNumber(1).should.be.bignumber.equal(
-        await newKeysManager.initialKeys.call(accounts[1])
+        await newKeysManager.getInitialKeyStatus.call(accounts[1])
       )
       await newKeysManager.migrateInitialKey(accounts[2]).should.be.rejectedWith(ERROR_MSG);
       new web3.BigNumber(0).should.be.bignumber.equal(
-        await newKeysManager.initialKeys.call(accounts[2])
+        await newKeysManager.getInitialKeyStatus.call(accounts[2])
       )
     })
   });

--- a/test/mockContracts/KeysManagerMock.sol
+++ b/test/mockContracts/KeysManagerMock.sol
@@ -4,11 +4,15 @@ import '../../contracts/KeysManager.sol';
 
 
 contract KeysManagerMock is KeysManager {
+    function getInitialKey(address _initialKey) public view returns(uint8) {
+        return getInitialKeyStatus(_initialKey);
+    }
+
     function setProxyStorage(address _proxyStorage) public {
         addressStorage[keccak256("proxyStorage")] = _proxyStorage;
     }
 
     function setInitEnabled() public {
-    	boolStorage[INIT_DISABLED] = false;
+        boolStorage[INIT_DISABLED] = false;
     }
 }


### PR DESCRIPTION
- (Mandatory) Description
This PR removes `KeysManager.initialKeys` and `KeysManager.getInitialKey` functions and adds `KeysManager.getInitialKeyStatus` function as it is suggested by MixBytes audit team.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Refactor)