### PR TITLE
(Fix) Removing usage of a free pointer from EternalStorageProxy's fallback function

### DIFF
--- a/contracts/eternal-storage/EternalStorageProxy.sol
+++ b/contracts/eternal-storage/EternalStorageProxy.sol
@@ -51,20 +51,27 @@ contract EternalStorageProxy is EternalStorage {
     * This function will return whatever the implementation call returns
     */
     // solhint-disable no-complex-fallback, no-inline-assembly
-    function() public payable {
+    function() external payable {
         address _impl = _implementation;
         require(_impl != address(0));
 
         assembly {
-            let ptr := mload(0x40)
-            calldatacopy(ptr, 0, calldatasize)
-            let result := delegatecall(gas, _impl, ptr, calldatasize, 0, 0)
-            let size := returndatasize
-            returndatacopy(ptr, 0, size)
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0
+            calldatacopy(0, 0, calldatasize)
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet
+            let result := delegatecall(gas, _impl, 0, calldatasize, 0, 0)
+
+            // Copy the returned data
+            returndatacopy(0, 0, returndatasize)
 
             switch result
-            case 0 { revert(ptr, size) }
-            default { return(ptr, size) }
+            // delegatecall returns 0 on error
+            case 0 { revert(0, returndatasize) }
+            default { return(0, returndatasize) }
         }
     }
     // solhint-enable no-complex-fallback, no-inline-assembly


### PR DESCRIPTION
**(Mandatory) Description**

Using `0` instead of `ptr` is safe as it is described in https://github.com/zeppelinos/zos-lib/issues/70:
1. Nothing can happen after the inline assembly block. It always runs `return` or `revert`, and both of them stop the EVM execution. So the ABI doesn't need to be followed after the assembly block.
2. The proxied contract uses a new address space after the `delegatecall`, so we can do whatever we want with the proxy's one.

I've tested the work of upgradable smart contracts after these changes by unit tests and `scripts/migrate/migrateAll.js` - the contracts work fine.

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Fix)