### PR TITLE
(Fix) Small fixes of KeysManager and EternalStorageProxy contracts

### DIFF
--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -242,6 +242,7 @@ contract KeysManager is EternalStorage, IKeysManager {
     )
         public
         onlyValidInitialKey
+        withinTotalLimit
     {
         require(_miningKey != address(0));
         require(_votingKey != address(0));

--- a/contracts/eternal-storage/EternalStorageProxy.sol
+++ b/contracts/eternal-storage/EternalStorageProxy.sol
@@ -107,8 +107,8 @@ contract EternalStorageProxy is EternalStorage {
      * @param implementation representing the address of the new implementation to be set.
      */
     function upgradeTo(address implementation) public onlyProxyStorage {
-        require(_implementation != implementation);
         require(implementation != address(0));
+        if (_implementation == implementation) return;
 
         uint256 _newVersion = _version + 1;
         assert(_newVersion > _version);

--- a/test/eternal_storage_proxy_test.js
+++ b/test/eternal_storage_proxy_test.js
@@ -115,10 +115,11 @@ contract('EternalStorageProxy [all features]', function (accounts) {
       await instance.upgradeTo(accounts[3], {from: accounts[1]}).should.be.fulfilled;
     });
     it('should not change implementation address if it is the same', async () => {
-      await instance.upgradeTo(
+      const result = await instance.upgradeTo(
         accounts[2],
         {from: accounts[1]}
-      ).should.be.rejectedWith(ERROR_MSG);
+      ).should.be.fulfilled;
+      result.logs.length.should.be.equal(0);
     });
     it('should not change implementation address if it is 0x0', async () => {
       await instance.upgradeTo(

--- a/truffle.js
+++ b/truffle.js
@@ -24,7 +24,7 @@ module.exports = {
     sokol: {
       host: "localhost",
       port: 8545,
-      gas: 6200000,
+      gas: 6400000,
       network_id: "*" // Match any network id
     },
   },


### PR DESCRIPTION
**(Mandatory) Description**
- `KeysManager.createKeys` function has been complemented with `withinTotalLimit` modifier.
- `EternalStorageProxy.upgradeTo` function now doesn't revert if a new implementation address is the same as a previous.
- Gas limit has been increased to 6400000 for `sokol` network in `truffle.js` to successfully deploy `KeysManager` and `VotingToChangeKeys` contracts with `migrations/2_deploy_contract.js` script.

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Fix)