### PR TITLE
(Fix) Finalization without reverts, optimizations and unit tests updates

### DIFF
--- a/contracts/BallotsStorage.sol
+++ b/contracts/BallotsStorage.sol
@@ -5,11 +5,13 @@ import "./interfaces/IKeysManager.sol";
 import "./interfaces/IProxyStorage.sol";
 import "./interfaces/IPoaNetworkConsensus.sol";
 import "./eternal-storage/EternalStorage.sol";
-import "./abstracts/ThresholdTypesEnum.sol";
+import "./abstracts/EnumBallotTypes.sol";
+import "./abstracts/EnumKeyTypes.sol";
+import "./abstracts/EnumThresholdTypes.sol";
 import "./libs/SafeMath.sol";
 
 
-contract BallotsStorage is EternalStorage, ThresholdTypesEnum, IBallotsStorage {
+contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumThresholdTypes, IBallotsStorage {
     using SafeMath for uint256;
 
     bytes32 internal constant INIT_DISABLED = keccak256("initDisabled");
@@ -28,6 +30,41 @@ contract BallotsStorage is EternalStorage, ThresholdTypesEnum, IBallotsStorage {
     modifier onlyVotingToChangeThreshold() {
         require(msg.sender == getVotingToChangeThreshold());
         _;
+    }
+
+    function areKeysBallotParamsValid(
+        uint256 _ballotType,
+        address _affectedKey,
+        uint256 _affectedKeyType,
+        address _miningKey
+    ) external view returns(bool) {
+        require(_ballotType >= uint256(BallotTypes.KeyAdding));
+        require(_ballotType <= uint256(BallotTypes.KeySwap));
+        require(_affectedKey != address(0));
+        require(_affectedKeyType >= uint256(KeyTypes.MiningKey));
+        require(_affectedKeyType <= uint256(KeyTypes.PayoutKey));
+
+        if (_ballotType == uint256(BallotTypes.KeyAdding)) {
+            return _areKeyAddingBallotParamsValid(
+                _affectedKey,
+                _affectedKeyType, 
+                _miningKey
+            );
+        }
+        if (_ballotType == uint256(BallotTypes.KeyRemoval)) {
+            return _areKeyRemovalBallotParamsValid(
+                _affectedKey,
+                _affectedKeyType,
+                _miningKey
+            );
+        }
+        if (_ballotType == uint256(BallotTypes.KeySwap)) {
+            return _areKeySwapBallotParamsValid(
+                _affectedKey,
+                _affectedKeyType,
+                _miningKey
+            );
+        }
     }
 
     function proxyStorage() public view returns(address) {
@@ -72,13 +109,15 @@ contract BallotsStorage is EternalStorage, ThresholdTypesEnum, IBallotsStorage {
     function setThreshold(uint256 _newValue, uint8 _thresholdType)
         public
         onlyVotingToChangeThreshold
+        returns(bool)
     {
-        require(_thresholdType > 0);
-        require(_thresholdType <= uint8(ThresholdTypes.MetadataChange));
-        require(_newValue > 0);
-        require(_newValue != getBallotThreshold(_thresholdType));
+        if (_thresholdType == 0) return false;
+        if (_thresholdType > uint8(ThresholdTypes.MetadataChange)) return false;
+        if (_newValue == 0) return false;
+        if (_newValue == getBallotThreshold(_thresholdType)) return false;
         _setThreshold(_newValue, _thresholdType);
         emit ThresholdChanged(_thresholdType, _newValue);
+        return true;
     }
 
     function getBallotThreshold(uint8 _ballotType) public view returns(uint256) {
@@ -109,17 +148,90 @@ contract BallotsStorage is EternalStorage, ThresholdTypesEnum, IBallotsStorage {
         return 200;
     }
 
-    function _initDisable() private {
+    function _areKeyAddingBallotParamsValid(
+        address _affectedKey,
+        uint256 _affectedKeyType,
+        address _miningKey
+    ) internal view returns(bool) {
+        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        if (_affectedKeyType == uint256(KeyTypes.MiningKey)) {
+            return !keysManager.checkIfMiningExisted(_miningKey, _affectedKey);
+        }
+        if (_affectedKeyType == uint256(KeyTypes.VotingKey)) {
+            require(_miningKey != keysManager.masterOfCeremony());
+            require(keysManager.miningKeyByVoting(_affectedKey) == address(0));
+            return _affectedKey != _miningKey && keysManager.isMiningActive(_miningKey);
+        }
+        if (_affectedKeyType == uint256(KeyTypes.PayoutKey)) {
+            require(keysManager.miningKeyByPayout(_affectedKey) == address(0));
+            return _affectedKey != _miningKey && keysManager.isMiningActive(_miningKey);
+        }
+    }
+
+    function _areKeyRemovalBallotParamsValid(
+        address _affectedKey,
+        uint256 _affectedKeyType,
+        address _miningKey
+    ) internal view returns(bool) {
+        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        require(keysManager.isMiningActive(_miningKey));
+        if (_affectedKeyType == uint256(KeyTypes.MiningKey)) {
+            return true;
+        }
+        if (_affectedKeyType == uint256(KeyTypes.VotingKey)) {
+            require(_affectedKey != _miningKey);
+            address votingKey = keysManager.getVotingByMining(_miningKey);
+            require(_affectedKey == votingKey);
+            return keysManager.isVotingActive(votingKey);
+        }
+        if (_affectedKeyType == uint256(KeyTypes.PayoutKey)) {
+            require(_affectedKey != _miningKey);
+            address payoutKey = keysManager.getPayoutByMining(_miningKey);
+            require(_affectedKey == payoutKey);
+            return keysManager.isPayoutActive(_miningKey);
+        }
+    }
+
+    function _areKeySwapBallotParamsValid(
+        address _affectedKey,
+        uint256 _affectedKeyType,
+        address _miningKey
+    ) internal view returns(bool) {
+        require(_affectedKey != _miningKey);
+        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        require(keysManager.isMiningActive(_miningKey));
+        if (_affectedKeyType == uint256(KeyTypes.MiningKey)) {
+            return !keysManager.checkIfMiningExisted(_miningKey, _affectedKey);
+        }
+        if (_affectedKeyType == uint256(KeyTypes.VotingKey)) {
+            address votingKey = keysManager.getVotingByMining(_miningKey);
+            require(_affectedKey != votingKey);
+            require(keysManager.miningKeyByVoting(_affectedKey) == address(0));
+            return keysManager.isVotingActive(votingKey);
+        }
+        if (_affectedKeyType == uint256(KeyTypes.PayoutKey)) {
+            address payoutKey = keysManager.getPayoutByMining(_miningKey);
+            require(_affectedKey != payoutKey);
+            require(keysManager.miningKeyByPayout(_affectedKey) == address(0));
+            return keysManager.isPayoutActive(_miningKey);
+        }
+    }
+
+    function _initDisable() internal {
         boolStorage[INIT_DISABLED] = true;
     }
 
-    function _getTotalNumberOfValidators() private view returns(uint256) {
+    function _getKeysManager() internal view returns(address) {
+        return IProxyStorage(proxyStorage()).getKeysManager();
+    }
+
+    function _getTotalNumberOfValidators() internal view returns(uint256) {
         IProxyStorage proxy = IProxyStorage(proxyStorage());
         IPoaNetworkConsensus poa = IPoaNetworkConsensus(proxy.getPoaConsensus());
         return poa.getCurrentValidatorsLengthWithoutMoC();
     }
 
-    function _setThreshold(uint256 _newValue, uint8 _thresholdType) private {
+    function _setThreshold(uint256 _newValue, uint8 _thresholdType) internal {
         uintStorage[
             keccak256(abi.encodePacked(BALLOT_THRESHOLDS, _thresholdType))
         ] = _newValue;

--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -175,40 +175,46 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
     function setContractAddress(uint256 _contractType, address _contractAddress)
         public
         onlyVotingToChangeProxy
+        returns(bool)
     {
-        require(mocInitialized());
-        require(initDisabled());
-        require(_contractAddress != address(0));
+        if (!mocInitialized()) return false;
+        if (!initDisabled()) return false;
+        if (_contractAddress == address(0)) return false;
+        bool success = false;
         if (_contractType == uint8(ContractTypes.KeysManager)) {
-            IEternalStorageProxy(
+            success = IEternalStorageProxy(
                 getKeysManager()
             ).upgradeTo(_contractAddress);
         } else if (_contractType == uint8(ContractTypes.VotingToChangeKeys)) {
-            IEternalStorageProxy(
+            success = IEternalStorageProxy(
                 getVotingToChangeKeys()
             ).upgradeTo(_contractAddress);
         } else if (_contractType == uint8(ContractTypes.VotingToChangeMinThreshold)) {
-            IEternalStorageProxy(
+            success = IEternalStorageProxy(
                 getVotingToChangeMinThreshold()
             ).upgradeTo(_contractAddress);
         } else if (_contractType == uint8(ContractTypes.VotingToChangeProxy)) {
-            IEternalStorageProxy(
+            success = IEternalStorageProxy(
                 getVotingToChangeProxy()
             ).upgradeTo(_contractAddress);
         } else if (_contractType == uint8(ContractTypes.BallotsStorage)) {
-            IEternalStorageProxy(
+            success = IEternalStorageProxy(
                 getBallotsStorage()
             ).upgradeTo(_contractAddress);
         } else if (_contractType == uint8(ContractTypes.PoaConsensus)) {
             _setPoaConsensus(_contractAddress);
+            success = true;
         } else if (_contractType == uint8(ContractTypes.ValidatorMetadata)) {
-            IEternalStorageProxy(
+            success = IEternalStorageProxy(
                 getValidatorMetadata()
             ).upgradeTo(_contractAddress);
         } else if (_contractType == uint8(ContractTypes.ProxyStorage)) {
-            IEternalStorageProxy(this).upgradeTo(_contractAddress);
+            success = IEternalStorageProxy(this).upgradeTo(_contractAddress);
         }
-        emit AddressSet(_contractType, _contractAddress);
+        if (success) {
+            emit AddressSet(_contractType, _contractAddress);
+        }
+        return success;
     }
     // solhint-enable code-complexity
 

--- a/contracts/ValidatorMetadata.sol
+++ b/contracts/ValidatorMetadata.sol
@@ -5,10 +5,10 @@ import "./interfaces/IBallotsStorage.sol";
 import "./interfaces/IProxyStorage.sol";
 import "./interfaces/IKeysManager.sol";
 import "./eternal-storage/EternalStorage.sol";
-import "./abstracts/ThresholdTypesEnum.sol";
+import "./abstracts/EnumThresholdTypes.sol";
 
 
-contract ValidatorMetadata is EternalStorage, ThresholdTypesEnum {
+contract ValidatorMetadata is EternalStorage, EnumThresholdTypes {
     using SafeMath for uint256;
 
     bytes32 internal constant INIT_METADATA_DISABLED = keccak256("initMetadataDisabled");

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -41,34 +41,17 @@ contract VotingToChangeProxyAddress is IVotingToChangeProxyAddress, VotingToChan
         bool canBeFinalizedNow,
         bool hasAlreadyVoted
     ) {
-        startTime = getStartTime(_id);
-        endTime = getEndTime(_id);
-        totalVoters = getTotalVoters(_id);
-        progress = getProgress(_id);
-        isFinalized = getIsFinalized(_id);
-        proposedValue = getProposedValue(_id);
-        contractType = getContractType(_id);
-        creator = getCreator(_id);
-        memo = getMemo(_id);
+        startTime = _getStartTime(_id);
+        endTime = _getEndTime(_id);
+        totalVoters = _getTotalVoters(_id);
+        progress = _getProgress(_id);
+        isFinalized = _getIsFinalized(_id);
+        proposedValue = _getProposedValue(_id);
+        contractType = _getContractType(_id);
+        creator = _getCreator(_id);
+        memo = _getMemo(_id);
         canBeFinalizedNow = _canBeFinalizedNow(_id);
         hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
-    }
-
-    function getContractType(uint256 _id) public view returns(uint256) {
-        return uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, CONTRACT_TYPE))
-        ];
-    }
-    
-    function getGlobalMinThresholdOfVoters() public view returns(uint256) {
-        IBallotsStorage ballotsStorage = IBallotsStorage(getBallotsStorage());
-        return ballotsStorage.getProxyThreshold();
-    }
-
-    function getProposedValue(uint256 _id) public view returns(address) {
-        return addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, PROPOSED_VALUE))
-        ];
     }
 
     function migrateBasicOne(
@@ -89,17 +72,34 @@ contract VotingToChangeProxyAddress is IVotingToChangeProxyAddress, VotingToChan
             _memo,
             _voters
         );
-        IVotingToChangeProxyAddress prev =
-            IVotingToChangeProxyAddress(_prevVotingToChange);
+        IVotingToChangeProxyAddressPrev prev =
+            IVotingToChangeProxyAddressPrev(_prevVotingToChange);
         _setProposedValue(_id, prev.getProposedValue(_id));
         _setContractType(_id, prev.getContractType(_id));
     }
 
-    function _finalizeBallotInner(uint256 _id) internal {
-        IProxyStorage(proxyStorage()).setContractAddress(
-            getContractType(_id),
-            getProposedValue(_id)
+    function _finalizeBallotInner(uint256 _id) internal returns(bool) {
+        return IProxyStorage(proxyStorage()).setContractAddress(
+            _getContractType(_id),
+            _getProposedValue(_id)
         );
+    }
+
+    function _getContractType(uint256 _id) internal view returns(uint256) {
+        return uintStorage[
+            keccak256(abi.encodePacked(VOTING_STATE, _id, CONTRACT_TYPE))
+        ];
+    }
+
+    function _getGlobalMinThresholdOfVoters() internal view returns(uint256) {
+        IBallotsStorage ballotsStorage = IBallotsStorage(_getBallotsStorage());
+        return ballotsStorage.getProxyThreshold();
+    }
+
+    function _getProposedValue(uint256 _id) internal view returns(address) {
+        return addressStorage[
+            keccak256(abi.encodePacked(VOTING_STATE, _id, PROPOSED_VALUE))
+        ];
     }
 
     function _setContractType(uint256 _ballotId, uint256 _value) private {

--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -52,7 +52,7 @@ contract VotingToManageEmissionFunds is VotingTo {
             _endTime,
             _memo,
             uint8(QuorumStates.InProgress),
-            getMiningByVotingKey(msg.sender)
+            _getMiningByVotingKey(msg.sender)
         );
         _setSendVotes(ballotId, 0);
         _setBurnVotes(ballotId, 0);
@@ -81,9 +81,9 @@ contract VotingToManageEmissionFunds is VotingTo {
     function finalize(uint256 _id) public onlyValidVotingKey(msg.sender) {
         require(_id < nextBallotId());
         require(_id == nextBallotId().sub(1));
-        require(getStartTime(_id) <= getTime());
+        require(_getStartTime(_id) <= getTime());
         require(!isActive(_id));
-        require(!getIsFinalized(_id));
+        require(!_getIsFinalized(_id));
         require(!previousBallotFinalized());
         _finalize(_id);
     }
@@ -105,11 +105,11 @@ contract VotingToManageEmissionFunds is VotingTo {
         uint256 sendVotes,
         address receiver
     ) {
-        startTime = getStartTime(_id);
-        endTime = getEndTime(_id);
-        isFinalized = getIsFinalized(_id);
-        creator = getCreator(_id);
-        memo = getMemo(_id);
+        startTime = _getStartTime(_id);
+        endTime = _getEndTime(_id);
+        isFinalized = _getIsFinalized(_id);
+        creator = _getCreator(_id);
+        memo = _getMemo(_id);
         hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
         amount = getAmount(_id);
         burnVotes = getBurnVotes(_id);
@@ -178,7 +178,7 @@ contract VotingToManageEmissionFunds is VotingTo {
     }
 
     function vote(uint256 _id, uint8 _choice) public onlyValidVotingKey(msg.sender) {
-        require(!getIsFinalized(_id));
+        require(!_getIsFinalized(_id));
         require(isValidVote(_id, msg.sender));
         if (_choice == uint(ActionChoice.Send)) {
             _setSendVotes(_id, getSendVotes(_id).add(1));
@@ -189,7 +189,7 @@ contract VotingToManageEmissionFunds is VotingTo {
         } else {
             revert();
         }
-        address miningKey = getMiningByVotingKey(msg.sender);
+        address miningKey = _getMiningByVotingKey(msg.sender);
         _votersAdd(_id, miningKey);
         emit Vote(_id, _choice, msg.sender, getTime(), miningKey);
 

--- a/contracts/abstracts/EnumBallotTypes.sol
+++ b/contracts/abstracts/EnumBallotTypes.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.24;
+
+
+contract EnumBallotTypes {
+    enum BallotTypes {
+        Invalid,
+        KeyAdding,
+        KeyRemoval,
+        KeySwap,
+        MinThreshold,
+        ProxyAddress,
+        ManageEmissionFunds
+    }
+}

--- a/contracts/abstracts/EnumKeyTypes.sol
+++ b/contracts/abstracts/EnumKeyTypes.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.24;
+
+
+contract EnumKeyTypes {
+    enum KeyTypes {Invalid, MiningKey, VotingKey, PayoutKey}
+}

--- a/contracts/abstracts/EnumThresholdTypes.sol
+++ b/contracts/abstracts/EnumThresholdTypes.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
 
-contract ThresholdTypesEnum {
+contract EnumThresholdTypes {
     enum ThresholdTypes {Invalid, Keys, MetadataChange}
 }

--- a/contracts/eternal-storage/EternalStorageProxy.sol
+++ b/contracts/eternal-storage/EternalStorageProxy.sol
@@ -106,16 +106,18 @@ contract EternalStorageProxy is EternalStorage {
      * @dev Allows ProxyStorage contract to upgrade the current implementation.
      * @param implementation representing the address of the new implementation to be set.
      */
-    function upgradeTo(address implementation) public onlyProxyStorage {
-        require(implementation != address(0));
-        if (_implementation == implementation) return;
+    function upgradeTo(address implementation) public onlyProxyStorage returns(bool) {
+        if (implementation == address(0)) return false;
+        if (_implementation == implementation) return false;
 
         uint256 _newVersion = _version + 1;
-        assert(_newVersion > _version);
-        _version = _newVersion;
+        if (_newVersion <= _version) return false;
 
+        _version = _newVersion;
         _implementation = implementation;
+
         emit Upgraded(_version, _implementation);
+        return true;
     }
 
     function _setProxyStorage(address _proxyStorage) private {

--- a/contracts/interfaces/IBallotsStorage.sol
+++ b/contracts/interfaces/IBallotsStorage.sol
@@ -2,7 +2,8 @@ pragma solidity ^0.4.24;
 
 
 interface IBallotsStorage {
-    function setThreshold(uint256, uint8) external;
+    function setThreshold(uint256, uint8) external returns(bool);
+    function areKeysBallotParamsValid(uint256, address, uint256, address) external view returns(bool);
     function getBallotThreshold(uint8) external view returns(uint256);
     function getVotingToChangeThreshold() external view returns(address);
     function getProxyThreshold() external view returns(uint256);

--- a/contracts/interfaces/IEternalStorageProxy.sol
+++ b/contracts/interfaces/IEternalStorageProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.4.24;
 
 
 interface IEternalStorageProxy {
-    function upgradeTo(address) external;
+    function upgradeTo(address) external returns(bool);
 }

--- a/contracts/interfaces/IKeysManager.sol
+++ b/contracts/interfaces/IKeysManager.sol
@@ -2,19 +2,20 @@ pragma solidity ^0.4.24;
 
 
 interface IKeysManager {
-    function addMiningKey(address) external;
-    function addVotingKey(address, address) external;
-    function addPayoutKey(address, address) external;
+    function addMiningKey(address) external returns(bool);
+    function addVotingKey(address, address) external returns(bool);
+    function addPayoutKey(address, address) external returns(bool);
     function createKeys(address, address, address) external;
     function initiateKeys(address) external;
     function migrateInitialKey(address) external;
     function migrateMiningKey(address, uint8) external;
-    function removeMiningKey(address) external;
-    function removeVotingKey(address) external;
-    function removePayoutKey(address) external;
-    function swapMiningKey(address, address) external;
-    function swapVotingKey(address, address) external;
-    function swapPayoutKey(address, address) external;
+    function removeMiningKey(address) external returns(bool);
+    function removeVotingKey(address) external returns(bool);
+    function removePayoutKey(address) external returns(bool);
+    function swapMiningKey(address, address) external returns(bool);
+    function swapVotingKey(address, address) external returns(bool);
+    function swapPayoutKey(address, address) external returns(bool);
+    function checkIfMiningExisted(address, address) external view returns(bool);
     function initialKeysCount() external view returns(uint256);
     function isMiningActive(address) external view returns(bool);
     function isVotingActive(address) external view returns(bool);
@@ -26,6 +27,7 @@ interface IKeysManager {
     function getMiningKeyByVoting(address) external view returns(address);
     function getInitialKeyStatus(address) external view returns(uint8);
     function masterOfCeremony() external view returns(address);
+    function maxOldMiningKeysDeepCheck() external pure returns(uint8);
     function miningKeyByPayout(address) external view returns(address);
     function miningKeyByVoting(address) external view returns(address);
 }

--- a/contracts/interfaces/IPoaNetworkConsensus.sol
+++ b/contracts/interfaces/IPoaNetworkConsensus.sol
@@ -2,10 +2,10 @@ pragma solidity ^0.4.24;
 
 
 interface IPoaNetworkConsensus {
-    function addValidator(address, bool) external;
+    function addValidator(address, bool) external returns(bool);
     function finalizeChange() external;
-    function removeValidator(address, bool) external;
-    function swapValidatorKey(address, address) external;
+    function removeValidator(address, bool) external returns(bool);
+    function swapValidatorKey(address, address) external returns(bool);
     function isMasterOfCeremonyRemoved() external view returns(bool);
     function isValidator(address) external view returns(bool);
     function getCurrentValidatorsLength() external view returns(uint256);

--- a/contracts/interfaces/IProxyStorage.sol
+++ b/contracts/interfaces/IProxyStorage.sol
@@ -6,7 +6,7 @@ interface IProxyStorage {
         address, address, address, address, address, address, address, address
     ) external;
 
-    function setContractAddress(uint256, address) external;
+    function setContractAddress(uint256, address) external returns(bool);
     function isValidator(address) external view returns(bool);
     function getBallotsStorage() external view returns(address);
     function getKeysManager() external view returns(address);

--- a/contracts/interfaces/IVotingToChange.sol
+++ b/contracts/interfaces/IVotingToChange.sol
@@ -6,6 +6,15 @@ interface IVotingToChange {
     function activeBallots(uint256) external view returns(uint256);
     function activeBallotsLength() external view returns(uint256);
     function validatorActiveBallots(address) external view returns(uint256);
+    function getMinThresholdOfVoters(uint256) external view returns(uint256);
+}
+
+
+interface IVotingToChangePrev {
+    function nextBallotId() external view returns(uint256);
+    function activeBallots(uint256) external view returns(uint256);
+    function activeBallotsLength() external view returns(uint256);
+    function validatorActiveBallots(address) external view returns(uint256);
     function getStartTime(uint256) external view returns(uint256);
     function getEndTime(uint256) external view returns(uint256);
     function getTotalVoters(uint256) external view returns(uint256);

--- a/contracts/interfaces/IVotingToChangeKeys.sol
+++ b/contracts/interfaces/IVotingToChangeKeys.sol
@@ -6,14 +6,18 @@ interface IVotingToChangeKeys {
     function activeBallots(uint256) external view returns(uint256);
     function activeBallotsLength() external view returns(uint256);
     function validatorActiveBallots(address) external view returns(uint256);
-    function getStartTime(uint256) external view returns(uint256);
-    function getEndTime(uint256) external view returns(uint256);
+    function getMinThresholdOfVoters(uint256) external view returns(uint256);
+}
+
+
+interface IVotingToChangeKeysPrev {
+    function nextBallotId() external view returns(uint256);
+    function activeBallots(uint256) external view returns(uint256);
+    function activeBallotsLength() external view returns(uint256);
+    function validatorActiveBallots(address) external view returns(uint256);
     function getAffectedKey(uint256) external view returns(address);
     function getAffectedKeyType(uint256) external view returns(uint256);
     function getMiningKey(uint256) external view returns(address);
-    function getTotalVoters(uint256) external view returns(uint256);
-    function getProgress(uint256) external view returns(int256);
-    function getIsFinalized(uint256) external view returns(bool);
     function getBallotType(uint256) external view returns(uint256);
     function getMinThresholdOfVoters(uint256) external view returns(uint256);
 }

--- a/contracts/interfaces/IVotingToChangeMinThreshold.sol
+++ b/contracts/interfaces/IVotingToChangeMinThreshold.sol
@@ -6,11 +6,15 @@ interface IVotingToChangeMinThreshold {
     function activeBallots(uint256) external view returns(uint256);
     function activeBallotsLength() external view returns(uint256);
     function validatorActiveBallots(address) external view returns(uint256);
-    function getStartTime(uint256) external view returns(uint256);
-    function getEndTime(uint256) external view returns(uint256);
-    function getTotalVoters(uint256) external view returns(uint256);
-    function getProgress(uint256) external view returns(int256);
-    function getIsFinalized(uint256) external view returns(bool);
+    function getMinThresholdOfVoters(uint256) external view returns(uint256);
+}
+
+
+interface IVotingToChangeMinThresholdPrev {
+    function nextBallotId() external view returns(uint256);
+    function activeBallots(uint256) external view returns(uint256);
+    function activeBallotsLength() external view returns(uint256);
+    function validatorActiveBallots(address) external view returns(uint256);
     function getMinThresholdOfVoters(uint256) external view returns(uint256);
     function getProposedValue(uint256) external view returns(uint256);
 }

--- a/contracts/interfaces/IVotingToChangeProxyAddress.sol
+++ b/contracts/interfaces/IVotingToChangeProxyAddress.sol
@@ -6,11 +6,15 @@ interface IVotingToChangeProxyAddress {
     function activeBallots(uint256) external view returns(uint256);
     function activeBallotsLength() external view returns(uint256);
     function validatorActiveBallots(address) external view returns(uint256);
-    function getStartTime(uint256) external view returns(uint256);
-    function getEndTime(uint256) external view returns(uint256);
-    function getTotalVoters(uint256) external view returns(uint256);
-    function getProgress(uint256) external view returns(int256);
-    function getIsFinalized(uint256) external view returns(bool);
+    function getMinThresholdOfVoters(uint256) external view returns(uint256);
+}
+
+
+interface IVotingToChangeProxyAddressPrev {
+    function nextBallotId() external view returns(uint256);
+    function activeBallots(uint256) external view returns(uint256);
+    function activeBallotsLength() external view returns(uint256);
+    function validatorActiveBallots(address) external view returns(uint256);
     function getMinThresholdOfVoters(uint256) external view returns(uint256);
     function getProposedValue(uint256) external view returns(address);
     function getContractType(uint256) external view returns(uint256);

--- a/scripts/migrate/migrateKeys.js
+++ b/scripts/migrate/migrateKeys.js
@@ -215,9 +215,11 @@ async function migrateAndCheck(privateKey) {
 		console.log('');
 	} catch (err) {
 		if (ONLY_CHECK) {
-			console.log('Something is wrong: ' + err.message);
+			console.log('Something is wrong:');
+			console.log(err);
 		} else {
-			console.log('Cannot migrate KeysManager: ' + err.message);
+			console.log('Cannot migrate KeysManager:');
+			console.log(err);
 		}
 		process.exit(1);
 	}

--- a/scripts/migrate/migrateMetadataNew.js
+++ b/scripts/migrate/migrateMetadataNew.js
@@ -139,9 +139,11 @@ async function migrateAndCheck(privateKey) {
 		success = true;
 	} catch (err) {
 		if (ONLY_CHECK) {
-			console.log('Something is wrong: ' + err.message);
+			console.log('Something is wrong:');
+			console.log(err);
 		} else {
-			console.log('Cannot migrate ValidatorMetadata: ' + err.message);
+			console.log('Cannot migrate ValidatorMetadata:');
+			console.log(err);
 		}
 	}
 

--- a/test/eternal_storage_proxy_test.js
+++ b/test/eternal_storage_proxy_test.js
@@ -112,7 +112,8 @@ contract('EternalStorageProxy [all features]', function (accounts) {
     });
     it('may only be called by ProxyStorage', async () => {
       await instance.upgradeTo(accounts[3]).should.be.rejectedWith(ERROR_MSG);
-      await instance.upgradeTo(accounts[3], {from: accounts[1]}).should.be.fulfilled;
+      const {logs} = await instance.upgradeTo(accounts[3], {from: accounts[1]});
+      logs[0].event.should.be.equal("Upgraded");
     });
     it('should not change implementation address if it is the same', async () => {
       const result = await instance.upgradeTo(
@@ -122,10 +123,11 @@ contract('EternalStorageProxy [all features]', function (accounts) {
       result.logs.length.should.be.equal(0);
     });
     it('should not change implementation address if it is 0x0', async () => {
-      await instance.upgradeTo(
+      const result = await instance.upgradeTo(
         '0x0000000000000000000000000000000000000000',
         {from: accounts[1]}
-      ).should.be.rejectedWith(ERROR_MSG);
+      );
+      result.logs.length.should.be.equal(0);
     });
     it('should change implementation address', async () => {
       const {logs} = await instance.upgradeTo(
@@ -139,10 +141,11 @@ contract('EternalStorageProxy [all features]', function (accounts) {
     });
     it('should increment version', async () => {
       (await instance.version.call()).should.be.bignumber.equal(0);
-      await instance.upgradeTo(
+      const {logs} = await instance.upgradeTo(
         accounts[3],
         {from: accounts[1]}
-      ).should.be.fulfilled;
+      );
+      logs[0].event.should.be.equal("Upgraded");
       (await instance.version.call()).should.be.bignumber.equal(1);
     });
   });

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -10,8 +10,9 @@ require('chai')
   .use(require('chai-bignumber')(web3.BigNumber))
   .should();
 
+let keysManager, keysManagerEternalStorage;
 contract('KeysManager [all features]', function (accounts) {
-  let keysManager, poaNetworkConsensusMock, proxyStorageMock;
+  let poaNetworkConsensusMock, proxyStorageMock;
 
   beforeEach(async () => {
     masterOfCeremony = accounts[0];
@@ -23,7 +24,7 @@ contract('KeysManager [all features]', function (accounts) {
     await proxyStorageMock.init(poaNetworkConsensusMock.address).should.be.fulfilled;
     
     keysManager = await KeysManagerMock.new();
-    const keysManagerEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, keysManager.address);
+    keysManagerEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, keysManager.address);
     keysManager = await KeysManagerMock.at(keysManagerEternalStorage.address);
     await keysManager.init(
       "0x0000000000000000000000000000000000000000",
@@ -251,16 +252,16 @@ contract('KeysManager [all features]', function (accounts) {
     it('may only be called if KeysManager.init had been called before', async () => {
       await keysManager.setInitEnabled().should.be.fulfilled;
       await proxyStorageMock.setVotingContractMock(accounts[2]);
-      await keysManager.addMiningKey(accounts[1], {from: accounts[2]}).should.be.rejectedWith(ERROR_MSG);
+      await addMiningKey(accounts[1], false, {from: accounts[2]});
     });
     it('should only be called from votingToChangeKeys', async () => {
       await keysManager.addMiningKey(accounts[1],{from: accounts[5]}).should.be.rejectedWith(ERROR_MSG);
       await proxyStorageMock.setVotingContractMock(accounts[2]);
-      await keysManager.addMiningKey(accounts[1], {from: accounts[2]}).should.be.fulfilled;
+      await addMiningKey(accounts[1], true, {from: accounts[2]});
     })
     it('should not let add more than maxLimit', async () => {
       await poaNetworkConsensusMock.setCurrentValidatorsLength(2001);
-      await keysManager.addMiningKey(accounts[2]).should.be.rejectedWith(ERROR_MSG);
+      await addMiningKey(accounts[2], false);
     })
     it('should set validatorKeys hash', async () => {
       const {logs} = await keysManager.addMiningKey(accounts[2]).should.be.fulfilled;
@@ -280,18 +281,18 @@ contract('KeysManager [all features]', function (accounts) {
 
   describe('#addVotingKey', async () => {
     it('may only be called if KeysManager.init had been called before', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
       await keysManager.setInitEnabled().should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await addVotingKey(accounts[2], accounts[1], false);
     });
     it('may only be called if params are not the same', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[1], accounts[1]).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addVotingKey(accounts[1], accounts[1], false);
+      await addVotingKey(accounts[2], accounts[1], true);
     });
     it('should add VotingKey', async () => {
-      await keysManager.addVotingKey(accounts[2],accounts[1], {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await keysManager.addVotingKey(accounts[2], accounts[1], {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
+      await addMiningKey(accounts[1], true);
       const {logs} = await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.fulfilled;
       true.should.be.equal(await keysManager.isVotingActive.call(accounts[2]));
       logs[0].event.should.be.equal('VotingKeyChanged');
@@ -303,14 +304,15 @@ contract('KeysManager [all features]', function (accounts) {
       miningKey.should.be.equal(accounts[1]);
     })
     it('should only be called if mining is active', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await addMiningKey(accounts[1], true);
+      const {logs} = await keysManager.removeMiningKey(accounts[1]);
+      logs[0].event.should.equal("MiningKeyChanged");
+      await addVotingKey(accounts[2], accounts[1], false);
     })
     it('swaps keys if voting already exists', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addVotingKey(accounts[2], accounts[1], true);
+      await addVotingKey(accounts[3], accounts[1], true);
       false.should.be.equal(await keysManager.isVotingActive.call(accounts[2]));
       true.should.be.equal(await keysManager.isVotingActive.call(accounts[3]));
       const validator = await keysManager.validatorKeys.call(accounts[1]);
@@ -326,18 +328,18 @@ contract('KeysManager [all features]', function (accounts) {
 
   describe('#addPayoutKey', async () => {
     it('may only be called if KeysManager.init had been called before', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
       await keysManager.setInitEnabled().should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await addPayoutKey(accounts[2], accounts[1], false);
     });
     it('may only be called if params are not the same', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[1], accounts[1]).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addPayoutKey(accounts[1], accounts[1], false);
+      await addPayoutKey(accounts[2], accounts[1], true);
     });
     it('should add PayoutKey', async () => {
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await addPayoutKey(accounts[2], accounts[1], false);
+      await addMiningKey(accounts[1], true);
       const {logs} = await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
       logs[0].event.should.be.equal('PayoutKeyChanged');
       logs[0].args.key.should.be.equal(accounts[2]);
@@ -349,15 +351,16 @@ contract('KeysManager [all features]', function (accounts) {
     })
 
     it('should only be called if mining is active', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await addMiningKey(accounts[1], true);
+      const {logs} = await keysManager.removeMiningKey(accounts[1]);
+      logs[0].event.should.equal("MiningKeyChanged");
+      await addPayoutKey(accounts[2], accounts[1], false);
     })
 
     it('swaps keys if voting already exists', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addPayoutKey(accounts[2], accounts[1], true);
+      await addPayoutKey(accounts[3], accounts[1], true);
       true.should.be.equal(await keysManager.isPayoutActive.call(accounts[1]));
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
@@ -378,15 +381,16 @@ contract('KeysManager [all features]', function (accounts) {
 
   describe('#removeMiningKey', async () => {
     it('may only be called if KeysManager.init had been called before', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addVotingKey(accounts[3], accounts[1], true);
       await keysManager.setInitEnabled().should.be.fulfilled;
-      await keysManager.removeMiningKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      let result = await keysManager.removeMiningKey(accounts[1]);
+      result.logs.length.should.be.equal(0);
     });
     it('should remove miningKey', async () => {
       await keysManager.removeMiningKey(accounts[1], {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addVotingKey(accounts[3], accounts[1], true);
       const {logs} = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
@@ -409,16 +413,18 @@ contract('KeysManager [all features]', function (accounts) {
       (await keysManager.miningKeyByPayout.call(validator[1])).should.be.equal(
         '0x0000000000000000000000000000000000000000'
       );
-      const result = await keysManager.removeVotingKey(accounts[1]).should.be.fulfilled;
+      let result = await keysManager.removeVotingKey(accounts[1]).should.be.fulfilled;
       result.logs.length.should.be.equal(0);
-      await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      result = await keysManager.removeMiningKey(accounts[1]);
+      result.logs.length.should.be.equal(0);
     })
   
     it('removes validator from poaConsensus', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
-      await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+      const {logs} = await keysManager.removeMiningKey(accounts[1]);
+      logs[0].event.should.equal("MiningKeyChanged");
       let currentValidatorsLength = await poaNetworkConsensusMock.getCurrentValidatorsLength.call();
       let pendingList = [];
       for(let i = 0; i < currentValidatorsLength.sub(1).toNumber(); i++){
@@ -447,7 +453,8 @@ contract('KeysManager [all features]', function (accounts) {
       await keysManager.initiateKeys('0x0000000000000000000000000000000000000010', {from: masterOfCeremony}).should.be.fulfilled;
       await keysManager.initiateKeys('0x0000000000000000000000000000000000000011', {from: masterOfCeremony}).should.be.fulfilled;
       
-      await keysManager.removeMiningKey(masterOfCeremony).should.be.rejectedWith(ERROR_MSG);
+      let result = await keysManager.removeMiningKey(masterOfCeremony);
+      result.logs.length.should.be.equal(0);
       (await poaNetworkConsensusMock.isMasterOfCeremonyRemoved.call()).should.be.equal(false);
       (await keysManager.masterOfCeremony.call()).should.be.equal(masterOfCeremony);
       (await poaNetworkConsensusMock.isValidator.call(masterOfCeremony)).should.be.equal(true);
@@ -455,7 +462,8 @@ contract('KeysManager [all features]', function (accounts) {
 
       await keysManager.initiateKeys('0x0000000000000000000000000000000000000012', {from: masterOfCeremony}).should.be.fulfilled;
       
-      await keysManager.removeMiningKey(masterOfCeremony).should.be.fulfilled;
+      result = await keysManager.removeMiningKey(masterOfCeremony);
+      result.logs[0].event.should.equal("MiningKeyChanged");
       (await poaNetworkConsensusMock.isMasterOfCeremonyRemovedPending.call()).should.be.equal(true);
       (await keysManager.masterOfCeremony.call()).should.be.equal(masterOfCeremony);
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
@@ -472,7 +480,7 @@ contract('KeysManager [all features]', function (accounts) {
       let result = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
       result.logs.length.should.be.equal(0);
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
       result = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
       result.logs[0].event.should.be.equal('MiningKeyChanged');
       result.logs[0].args.key.should.be.equal(accounts[1]);
@@ -490,19 +498,19 @@ contract('KeysManager [all features]', function (accounts) {
   describe('#removeVotingKey', async () => {
     it('may only be called if KeysManager.init had been called before', async () => {
       const {mining, voting, payout} = {mining: accounts[1], voting: accounts[3], payout: accounts[2]};
-      await keysManager.addMiningKey(mining).should.be.fulfilled;
-      await keysManager.addVotingKey(voting, mining).should.be.fulfilled;
-      await keysManager.addPayoutKey(payout, mining).should.be.fulfilled;
+      await addMiningKey(mining, true);
+      await addVotingKey(voting, mining, true);
+      await addPayoutKey(payout, mining, true);
       await keysManager.setInitEnabled().should.be.fulfilled;
-      await keysManager.removeVotingKey(mining).should.be.rejectedWith(ERROR_MSG);
+      await removeVotingKey(mining, false);
     });
     it('should be successful only for active voting key', async () => {
       const {mining, voting, payout} = {mining: accounts[1], voting: accounts[3], payout: accounts[2]};
-      await keysManager.addMiningKey(mining).should.be.fulfilled;
-      await keysManager.addPayoutKey(payout, mining).should.be.fulfilled;
+      await addMiningKey(mining, true);
+      await addPayoutKey(payout, mining, true);
       const result = await keysManager.removeVotingKey(mining).should.be.fulfilled;
       result.logs.length.should.be.equal(0);
-      await keysManager.addVotingKey(voting, mining).should.be.fulfilled;
+      await addVotingKey(voting, mining, true);
       const {logs} = await keysManager.removeVotingKey(mining).should.be.fulfilled;
       logs[0].event.should.be.equal('VotingKeyChanged');
       logs[0].args.key.should.be.equal(voting);
@@ -512,9 +520,9 @@ contract('KeysManager [all features]', function (accounts) {
     it('should remove votingKey', async () => {
       const {mining, voting, payout} = {mining: accounts[1], voting: accounts[3], payout: accounts[2]};
       await keysManager.removeVotingKey(mining, {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(mining).should.be.fulfilled;
-      await keysManager.addVotingKey(voting, mining).should.be.fulfilled;
-      await keysManager.addPayoutKey(payout, mining).should.be.fulfilled;
+      await addMiningKey(mining, true);
+      await addVotingKey(voting, mining, true);
+      await addPayoutKey(payout, mining, true);
       const {logs} = await keysManager.removeVotingKey(mining).should.be.fulfilled;
       const validator = await keysManager.validatorKeys.call(mining);
       validator.should.be.deep.equal(
@@ -534,18 +542,17 @@ contract('KeysManager [all features]', function (accounts) {
 
   describe('#removePayoutKey', async () => {
     it('may only be called if KeysManager.init had been called before', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addPayoutKey(accounts[2], accounts[1], true);
+      await addVotingKey(accounts[3], accounts[1], true);
       await keysManager.setInitEnabled().should.be.fulfilled;
-      await keysManager.removePayoutKey(accounts[1]).should.be.rejectedWith(ERROR_MSG);
+      await removePayoutKey(accounts[1], false);
     });
     it('should be successful only for active payout key', async () => {
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
-      const result = await keysManager.removePayoutKey(accounts[1]).should.be.fulfilled;
-      result.logs.length.should.be.equal(0);
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addVotingKey(accounts[3], accounts[1], true);
+      await removePayoutKey(accounts[1], false);
+      await addPayoutKey(accounts[2], accounts[1], true);
       const {logs} = await keysManager.removePayoutKey(accounts[1]).should.be.fulfilled;
       logs[0].event.should.be.equal('PayoutKeyChanged');
       logs[0].args.key.should.be.equal(accounts[2]);
@@ -554,9 +561,9 @@ contract('KeysManager [all features]', function (accounts) {
     });
     it('should remove payoutKey', async () => {
       await keysManager.removePayoutKey(accounts[1], {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addPayoutKey(accounts[2], accounts[1], true);
+      await addVotingKey(accounts[3], accounts[1], true);
       const {logs} = await keysManager.removePayoutKey(accounts[1]).should.be.fulfilled;
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
@@ -577,9 +584,9 @@ contract('KeysManager [all features]', function (accounts) {
   describe('#swapMiningKey', async () => {
     it('should swap mining key', async () => {
       await keysManager.swapMiningKey(accounts[1], accounts[2], {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.swapMiningKey(accounts[2], accounts[1]).should.be.fulfilled;
-      await keysManager.swapMiningKey(accounts[4], accounts[3]).should.be.rejectedWith(ERROR_MSG);
+      await addMiningKey(accounts[1], true);
+      await swapMiningKey(accounts[2], accounts[1], true);
+      await swapMiningKey(accounts[4], accounts[3], false);
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
         [ '0x0000000000000000000000000000000000000000',
@@ -600,7 +607,7 @@ contract('KeysManager [all features]', function (accounts) {
     it('should swap MoC', async () => {
       (await keysManager.masterOfCeremony.call()).should.be.equal(masterOfCeremony);
       (await poaNetworkConsensusMock.masterOfCeremony.call()).should.be.equal(masterOfCeremony);
-      await keysManager.swapMiningKey(accounts[1], masterOfCeremony).should.be.fulfilled;
+      await swapMiningKey(accounts[1], masterOfCeremony, true);
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
       (await keysManager.masterOfCeremony.call()).should.be.equal(accounts[1]);
@@ -613,9 +620,9 @@ contract('KeysManager [all features]', function (accounts) {
       const voting = accounts[2];
       const payout = accounts[3];
       const newMining = accounts[4];
-      await keysManager.addMiningKey(oldMining).should.be.fulfilled;
-      await keysManager.addVotingKey(voting, oldMining).should.be.fulfilled;
-      await keysManager.addPayoutKey(payout, oldMining).should.be.fulfilled;
+      await addMiningKey(oldMining, true);
+      await addVotingKey(voting, oldMining, true);
+      await addPayoutKey(payout, oldMining, true);
       const {logs} = await keysManager.swapMiningKey(newMining, oldMining).should.be.fulfilled;
       //const mining = await keysManager.getMiningKeyByVoting.call(voting);
       const validator = await keysManager.validatorKeys.call(oldMining);
@@ -650,9 +657,9 @@ contract('KeysManager [all features]', function (accounts) {
   describe('#swapVotingKey', async () => {
     it ('should swap voting key', async () => {
       await keysManager.swapVotingKey(accounts[1], accounts[2], {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addVotingKey(accounts[2], accounts[1]).should.be.fulfilled;
-      await keysManager.swapVotingKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addVotingKey(accounts[2], accounts[1], true);
+      await swapVotingKey(accounts[3], accounts[1], true);
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
         [ accounts[3],
@@ -667,9 +674,10 @@ contract('KeysManager [all features]', function (accounts) {
   describe('#swapPayoutKey', async () => {
     it('should swap payout key', async () => {
       await keysManager.swapPayoutKey(accounts[1], accounts[2], {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-      await keysManager.addPayoutKey(accounts[2], accounts[1]).should.be.fulfilled;
-      await keysManager.swapPayoutKey(accounts[3], accounts[1]).should.be.fulfilled;
+      await addMiningKey(accounts[1], true);
+      await addPayoutKey(accounts[2], accounts[1], true);
+      const {logs} = await keysManager.swapPayoutKey(accounts[3], accounts[1]);
+      logs[0].event.should.be.equal("PayoutKeyChanged");
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
         [ '0x0000000000000000000000000000000000000000',
@@ -735,8 +743,8 @@ contract('KeysManager [all features]', function (accounts) {
       const miningKey3 = accounts[6];
       
       await proxyStorageMock.setVotingContractMock(accounts[0]);
-      await keysManager.addMiningKey(miningKey2).should.be.fulfilled;
-      await keysManager.swapMiningKey(miningKey3, miningKey2).should.be.fulfilled;
+      await addMiningKey(miningKey2, true);
+      await swapMiningKey(miningKey3, miningKey2, true);
       await keysManager.initiateKeys(accounts[1], {from: masterOfCeremony}).should.be.fulfilled;
       await keysManager.createKeys(miningKey, votingKey, payoutKey, {from: accounts[1]}).should.be.fulfilled;
       
@@ -833,7 +841,6 @@ contract('KeysManager [all features]', function (accounts) {
 
   describe('#upgradeTo', async () => {
     let proxyStorageStubAddress;
-    let keysManagerEternalStorage;
     beforeEach(async () => {
       proxyStorageStubAddress = accounts[8];
       keysManager = await KeysManagerMock.new();
@@ -844,17 +851,17 @@ contract('KeysManager [all features]', function (accounts) {
       ).should.be.fulfilled;
       await keysManager.setProxyStorage(proxyStorageStubAddress);
     });
-    it('may be called only by ProxyStorage', async () => {
+    it('may only be called by ProxyStorage', async () => {
       let keysManagerNew = await KeysManagerNew.new();
       await keysManagerEternalStorage.upgradeTo(keysManagerNew.address, {from: accounts[0]}).should.be.rejectedWith(ERROR_MSG);
-      await keysManagerEternalStorage.upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress}).should.be.fulfilled;
+      await upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
     });
     it('should change implementation address', async () => {
       let keysManagerNew = await KeysManagerNew.new();
       let oldImplementation = await keysManager.implementation.call();
       let newImplementation = keysManagerNew.address;
       (await keysManagerEternalStorage.implementation.call()).should.be.equal(oldImplementation);
-      await keysManagerEternalStorage.upgradeTo(newImplementation, {from: proxyStorageStubAddress});
+      await upgradeTo(newImplementation, {from: proxyStorageStubAddress});
       keysManagerNew = await KeysManagerNew.at(keysManagerEternalStorage.address);
       (await keysManagerNew.implementation.call()).should.be.equal(newImplementation);
       (await keysManagerEternalStorage.implementation.call()).should.be.equal(newImplementation);
@@ -864,14 +871,14 @@ contract('KeysManager [all features]', function (accounts) {
       let oldVersion = await keysManager.version.call();
       let newVersion = oldVersion.add(1);
       (await keysManagerEternalStorage.version.call()).should.be.bignumber.equal(oldVersion);
-      await keysManagerEternalStorage.upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
+      await upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
       keysManagerNew = await KeysManagerNew.at(keysManagerEternalStorage.address);
       (await keysManagerNew.version.call()).should.be.bignumber.equal(newVersion);
       (await keysManagerEternalStorage.version.call()).should.be.bignumber.equal(newVersion);
     });
     it('new implementation should work', async () => {
       let keysManagerNew = await KeysManagerNew.new();
-      await keysManagerEternalStorage.upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
+      await upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
       keysManagerNew = await KeysManagerNew.at(keysManagerEternalStorage.address);
       (await keysManagerNew.initialized.call()).should.be.equal(false);
       await keysManagerNew.initialize();
@@ -879,7 +886,7 @@ contract('KeysManager [all features]', function (accounts) {
     });
     it('new implementation should use the same proxyStorage address', async () => {
       let keysManagerNew = await KeysManagerNew.new();
-      await keysManagerEternalStorage.upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
+      await upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
       keysManagerNew = await KeysManagerNew.at(keysManagerEternalStorage.address);
       (await keysManagerNew.proxyStorage.call()).should.be.equal(proxyStorageStubAddress);
     });
@@ -898,10 +905,78 @@ contract('KeysManager [all features]', function (accounts) {
       await keysManager.createKeys(accounts[2], accounts[3], accounts[4], {from: accounts[1]}).should.be.fulfilled;
       let keysManagerNew = await KeysManagerNew.new();
       await keysManager.setProxyStorage(proxyStorageStubAddress);
-      await keysManagerEternalStorage.upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
+      await upgradeTo(keysManagerNew.address, {from: proxyStorageStubAddress});
       keysManagerNew = await KeysManagerNew.at(keysManagerEternalStorage.address);
       keys = await keysManagerNew.validatorKeys.call(accounts[2]);
       keys.should.be.deep.equal([accounts[3], accounts[4], true, true, true]);
     });
   });
 });
+
+async function addMiningKey(_key, _shouldBeSuccessful, options) {
+  const result = await keysManager.addMiningKey(_key, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("MiningKeyChanged");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function swapMiningKey(_key, _oldMiningKey, _shouldBeSuccessful, options) {
+  const result = await keysManager.swapMiningKey(_key, _oldMiningKey, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("MiningKeyChanged");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function addVotingKey(_key, _miningKey, _shouldBeSuccessful, options) {
+  const result = await keysManager.addVotingKey(_key, _miningKey, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("VotingKeyChanged");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function removeVotingKey(_miningKey, _shouldBeSuccessful, options) {
+  const result = await keysManager.removeVotingKey(_miningKey, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("VotingKeyChanged");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function swapVotingKey(_key, _miningKey, _shouldBeSuccessful, options) {
+  const result = await keysManager.swapVotingKey(_key, _miningKey, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("VotingKeyChanged");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function addPayoutKey(_key, _miningKey, _shouldBeSuccessful, options) {
+  const result = await keysManager.addPayoutKey(_key, _miningKey, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("PayoutKeyChanged");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function removePayoutKey(_miningKey, _shouldBeSuccessful, options) {
+  const result = await keysManager.removePayoutKey(_miningKey, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("PayoutKeyChanged");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function upgradeTo(implementation, options) {
+  const {logs} = await keysManagerEternalStorage.upgradeTo(implementation, options);
+  logs[0].event.should.be.equal("Upgraded");
+}

--- a/test/metadata_upgrade_test.js
+++ b/test/metadata_upgrade_test.js
@@ -78,16 +78,17 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
 
     let metadataNew = await ValidatorMetadataNew.new();
     await metadataEternalStorage.setProxyStorage(accounts[6]);
-    await metadataEternalStorage.upgradeTo(metadataNew.address, {from: accounts[6]});
+    const {logs} = await metadataEternalStorage.upgradeTo(metadataNew.address, {from: accounts[6]});
+    logs[0].event.should.be.equal("Upgraded");
     await metadataEternalStorage.setProxyStorage(proxyStorageMock.address);
     metadata = await ValidatorMetadataNew.at(metadataEternalStorage.address);
 
-    await keysManager.addMiningKey(miningKey).should.be.fulfilled;
-    await keysManager.addVotingKey(votingKey, miningKey).should.be.fulfilled;
-    await keysManager.addMiningKey(miningKey2).should.be.fulfilled;
-    await keysManager.addVotingKey(votingKey2, miningKey2).should.be.fulfilled;
-    await keysManager.addMiningKey(miningKey3).should.be.fulfilled;
-    await keysManager.addVotingKey(votingKey3, miningKey3).should.be.fulfilled;
+    await addMiningKey(miningKey);
+    await addVotingKey(votingKey, miningKey);
+    await addMiningKey(miningKey2);
+    await addVotingKey(votingKey2, miningKey2);
+    await addMiningKey(miningKey3);
+    await addVotingKey(votingKey3, miningKey3);
     await metadata.setTime(55555);
   })
 
@@ -401,4 +402,14 @@ function pad(hex) {
     hex = hex + '0';
   }
   return hex;
+}
+
+async function addMiningKey(_key) {
+  const {logs} = await keysManager.addMiningKey(_key);
+  logs[0].event.should.be.equal("MiningKeyChanged");
+}
+
+async function addVotingKey(_key, _miningKey) {
+  const {logs} = await keysManager.addVotingKey(_key, _miningKey);
+  logs[0].event.should.be.equal("VotingKeyChanged");
 }

--- a/test/mockContracts/BallotsStorageMock.sol
+++ b/test/mockContracts/BallotsStorageMock.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.4.24;
+
+import '../../contracts/BallotsStorage.sol';
+
+
+contract BallotsStorageMock is BallotsStorage {
+    function setThresholdMock(uint256 _newValue, uint8 _thresholdType) public {
+        _setThreshold(_newValue, _thresholdType);
+    }
+}

--- a/test/mockContracts/EternalStorageProxyMock.sol
+++ b/test/mockContracts/EternalStorageProxyMock.sol
@@ -14,10 +14,6 @@ contract EternalStorageProxyMock is EternalStorageProxy {
     }
 
     function setProxyStorage(address _proxyStorage) public {
-        addressStorage[keccak256("proxyStorage")] = _proxyStorage;
-    }
-
-    function getProxyStorage() public view returns(address) {
-        return addressStorage[keccak256("proxyStorage")];
+        addressStorage[PROXY_STORAGE] = _proxyStorage;
     }
 }

--- a/test/mockContracts/KeysManagerMock.sol
+++ b/test/mockContracts/KeysManagerMock.sol
@@ -9,7 +9,7 @@ contract KeysManagerMock is KeysManager {
     }
 
     function setProxyStorage(address _proxyStorage) public {
-        addressStorage[keccak256("proxyStorage")] = _proxyStorage;
+        addressStorage[PROXY_STORAGE] = _proxyStorage;
     }
 
     function setInitEnabled() public {

--- a/test/mockContracts/ProxyStorageMock.sol
+++ b/test/mockContracts/ProxyStorageMock.sol
@@ -5,18 +5,18 @@ import '../../contracts/ProxyStorage.sol';
 
 contract ProxyStorageMock is ProxyStorage {
     function setVotingContractMock(address _newAddress) public {
-        addressStorage[keccak256("votingToChangeKeysEternalStorage")] = _newAddress;
+        addressStorage[VOTING_TO_CHANGE_KEYS_ETERNAL_STORAGE] = _newAddress;
     }
 
     function setVotingToChangeMinThresholdMock(address _newAddress) public {
-        addressStorage[keccak256("votingToChangeMinThresholdEternalStorage")] = _newAddress;
+        addressStorage[VOTING_TO_CHANGE_MIN_THRESHOLD_ETERNAL_STORAGE] = _newAddress;
     }
 
     function setVotingToChangeProxyMock(address _newAddress) public {
-        addressStorage[keccak256("votingToChangeProxyEternalStorage")] = _newAddress;
+        addressStorage[VOTING_TO_CHANGE_PROXY_ETERNAL_STORAGE] = _newAddress;
     }
 
     function setKeysManagerMock(address _newAddress) public {
-        addressStorage[keccak256("keysManagerEternalStorage")] = _newAddress;
+        addressStorage[KEYS_MANAGER_ETERNAL_STORAGE] = _newAddress;
     }
 }

--- a/test/mockContracts/RewardByTimeMock.sol
+++ b/test/mockContracts/RewardByTimeMock.sol
@@ -4,15 +4,13 @@ import '../../contracts/RewardByTime.sol';
 
 
 contract RewardByTimeMock is RewardByTime {
-    address internal systemAddress;
-    uint256 public time;
-
     modifier onlySystem {
-        require(msg.sender == systemAddress);
+        require(msg.sender == addressStorage[keccak256("systemAddress")]);
         _;
     }
 
     function getTime() public view returns(uint256) {
+        uint256 time = uintStorage[keccak256("mockTime")];
         if (time == 0) {
             return now;
         } else {
@@ -21,10 +19,10 @@ contract RewardByTimeMock is RewardByTime {
     }
 
     function setSystemAddress(address _address) public {
-        systemAddress = _address;
+        addressStorage[keccak256("systemAddress")] = _address;
     }
 
-    function setTime(uint256 _time) public {
-        time = _time;
+    function setTime(uint256 _newTime) public {
+        uintStorage[keccak256("mockTime")] = _newTime;
     }
 }

--- a/test/mockContracts/ValidatorMetadataMock.sol
+++ b/test/mockContracts/ValidatorMetadataMock.sol
@@ -4,17 +4,16 @@ import '../../contracts/ValidatorMetadata.sol';
 
 
 contract ValidatorMetadataMock is ValidatorMetadata {
-    uint256 public time;
-
-    function setTime(uint256 _time) public {
-        time = _time;
+    function getTime() public view returns(uint256) {
+        uint256 time = uintStorage[keccak256("mockTime")];
+        if (time == 0) {
+            return now;
+        } else {
+            return time;
+        }
     }
 
-    function getTime() public view returns(uint256) {
-        if (time == 0) {
-          return now;
-        } else {
-          return time;
-        }
+    function setTime(uint256 _newTime) public {
+        uintStorage[keccak256("mockTime")] = _newTime;
     }
 }

--- a/test/mockContracts/VotingToChangeKeysMock.sol
+++ b/test/mockContracts/VotingToChangeKeysMock.sol
@@ -1,20 +1,36 @@
 pragma solidity ^0.4.24;
 
+import './VotingToChangeMock.sol';
 import '../../contracts/VotingToChangeKeys.sol';
 
 
-contract VotingToChangeKeysMock is VotingToChangeKeys {
-    uint256 public time;
+contract VotingToChangeKeysMock is VotingToChangeMock, VotingToChangeKeys {
+    function getAffectedKey(uint256 _id) public view returns(address) {
+        return _getAffectedKey(_id);
+    }
 
-    function setTime(uint256 _newTime) public {
-        time = _newTime;
+    function getAffectedKeyType(uint256 _id) public view returns(uint256) {
+        return _getAffectedKeyType(_id);
+    }
+
+    function getBallotType(uint256 _id) public view returns(uint256) {
+        return _getBallotType(_id);
+    }
+
+    function getMiningKey(uint256 _id) public view returns(address) {
+        return _getMiningKey(_id);
     }
 
     function getTime() public view returns(uint256) {
+        uint256 time = uintStorage[keccak256("mockTime")];
         if (time == 0) {
             return now;
         } else {
             return time;
         }
+    }
+
+    function setTime(uint256 _newTime) public {
+        uintStorage[keccak256("mockTime")] = _newTime;
     }
 }

--- a/test/mockContracts/VotingToChangeMinThresholdMock.sol
+++ b/test/mockContracts/VotingToChangeMinThresholdMock.sol
@@ -1,24 +1,28 @@
 pragma solidity ^0.4.24;
 
+import './VotingToChangeMock.sol';
 import '../../contracts/VotingToChangeMinThreshold.sol';
 
 
-contract VotingToChangeMinThresholdMock is VotingToChangeMinThreshold {
-    uint256 public time;
-
-    function setTime(uint256 _newTime) public {
-        time = _newTime;
+contract VotingToChangeMinThresholdMock is VotingToChangeMock, VotingToChangeMinThreshold {
+    function getProposedValue(uint256 _id) public view returns(uint256) {
+        return _getProposedValue(_id);
     }
 
     function getTime() public view returns(uint256) {
+        uint256 time = uintStorage[keccak256("mockTime")];
         if (time == 0) {
             return now;
         } else {
-          return time;
+            return time;
         }
     }
 
     function setMinPossibleThreshold(uint256 _minPossibleThreshold) public {
         uintStorage[MIN_POSSIBLE_THRESHOLD] = _minPossibleThreshold;
+    }
+
+    function setTime(uint256 _newTime) public {
+        uintStorage[keccak256("mockTime")] = _newTime;
     }
 }

--- a/test/mockContracts/VotingToChangeMock.sol
+++ b/test/mockContracts/VotingToChangeMock.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.4.24;
+
+import '../../contracts/interfaces/IProxyStorage.sol';
+
+
+contract VotingToChangeMock {
+    function getBallotLimitPerValidator() public view returns(uint256) {
+        return _getBallotLimitPerValidator();
+    }
+
+    function getEndTime(uint256 _id) public view returns(uint256) {
+        return _getEndTime(_id);
+    }
+
+    function getIsFinalized(uint256 _id) public view returns(bool) {
+        return _getIsFinalized(_id);
+    }
+
+    function getKeysManager() public view returns(address) {
+        return IProxyStorage(proxyStorage()).getKeysManager();
+    }
+
+    function getProgress(uint256 _id) public view returns(int) {
+        return _getProgress(_id);
+    }
+
+    function getStartTime(uint256 _id) public view returns(uint256) {
+        return _getStartTime(_id);
+    }
+
+    function getTotalVoters(uint256 _id) public view returns(uint256) {
+        return _getTotalVoters(_id);
+    }
+
+    function hasMiningKeyAlreadyVoted(uint256 _id, address _miningKey)
+        public
+        view
+        returns(bool)
+    {
+        return _hasMiningKeyAlreadyVoted(_id, _miningKey);
+    }
+
+    function proxyStorage() public view returns(address);
+
+    function _getBallotLimitPerValidator() internal view returns(uint256);
+    function _getEndTime(uint256) internal view returns(uint256);
+    function _getIsFinalized(uint256) internal view returns(bool);
+    function _getProgress(uint256) internal view returns(int);
+    function _getStartTime(uint256) internal view returns(uint256);
+    function _getTotalVoters(uint256) internal view returns(uint256);
+    function _hasMiningKeyAlreadyVoted(uint256, address) internal view returns(bool);
+}

--- a/test/mockContracts/VotingToChangeProxyAddressMock.sol
+++ b/test/mockContracts/VotingToChangeProxyAddressMock.sol
@@ -1,20 +1,28 @@
 pragma solidity ^0.4.24;
 
+import './VotingToChangeMock.sol';
 import '../../contracts/VotingToChangeProxyAddress.sol';
 
 
-contract VotingToChangeProxyAddressMock is VotingToChangeProxyAddress {
-    uint256 public time;
+contract VotingToChangeProxyAddressMock is VotingToChangeMock, VotingToChangeProxyAddress {
+    function getContractType(uint256 _id) public view returns(uint256) {
+        return _getContractType(_id);
+    }
 
-    function setTime(uint256 _newTime) public {
-        time = _newTime;
+    function getProposedValue(uint256 _id) public view returns(address) {
+        return _getProposedValue(_id);
     }
 
     function getTime() public view returns(uint256) {
+        uint256 time = uintStorage[keccak256("mockTime")];
         if (time == 0) {
             return now;
         } else {
             return time;
         }
+    }
+
+    function setTime(uint256 _newTime) public {
+        uintStorage[keccak256("mockTime")] = _newTime;
     }
 }

--- a/test/mockContracts/VotingToManageEmissionFundsMock.sol
+++ b/test/mockContracts/VotingToManageEmissionFundsMock.sol
@@ -4,17 +4,28 @@ import '../../contracts/VotingToManageEmissionFunds.sol';
 
 
 contract VotingToManageEmissionFundsMock is VotingToManageEmissionFunds {
-    uint256 public time;
-
-    function setTime(uint256 _newTime) public {
-        time = _newTime;
+    function getKeysManager() public view returns(address) {
+        return IProxyStorage(proxyStorage()).getKeysManager();
     }
 
     function getTime() public view returns(uint256) {
+        uint256 time = uintStorage[keccak256("mockTime")];
         if (time == 0) {
             return now;
         } else {
             return time;
         }
+    }
+
+    function hasMiningKeyAlreadyVoted(uint256 _id, address _miningKey)
+        public
+        view
+        returns(bool)
+    {
+        return _hasMiningKeyAlreadyVoted(_id, _miningKey);
+    }
+
+    function setTime(uint256 _newTime) public {
+        uintStorage[keccak256("mockTime")] = _newTime;
     }
 }

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -174,18 +174,18 @@ contract('ProxyStorage [all features]', function (accounts) {
     it('can only be called from votingToChangeProxy address', async () => {
       await proxyStorage.setContractAddress(1, accounts[2], {from: accounts[0]}).should.be.rejectedWith(ERROR_MSG);
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(1, accounts[2], {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(1, accounts[2], true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
     })
     it('cannot be set to 0x0 address', async () => {
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(1, '0x0000000000000000000000000000000000000000', {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
+      await setContractAddress(1, '0x0000000000000000000000000000000000000000', false, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
     })
     it('sets keysManager', async () => {
       let keysManagerNew = await KeysManager.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(1, keysManagerNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(1, keysManagerNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getKeysManager.call();
@@ -198,7 +198,7 @@ contract('ProxyStorage [all features]', function (accounts) {
     it('sets votingToChangeKeys', async () => {
       let votingToChangeKeysNew = await VotingToChangeKeys.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(2, votingToChangeKeysNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(2, votingToChangeKeysNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getVotingToChangeKeys.call();
@@ -211,7 +211,7 @@ contract('ProxyStorage [all features]', function (accounts) {
     it('sets votingToChangeMinThreshold', async () => {
       let votingToChangeMinThresholdNew = await VotingToChangeMinThreshold.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(3, votingToChangeMinThresholdNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(3, votingToChangeMinThresholdNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getVotingToChangeMinThreshold.call();
@@ -228,7 +228,7 @@ contract('ProxyStorage [all features]', function (accounts) {
       let ballotsStorageNew = await BallotsStorage.new();
 
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(5, ballotsStorageNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(5, ballotsStorageNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getBallotsStorage.call();
@@ -240,7 +240,7 @@ contract('ProxyStorage [all features]', function (accounts) {
     })
     it('sets poaConsensus', async () => {
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(6, accounts[5], {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(6, accounts[5], true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       accounts[5].should.be.equal(
         await proxyStorage.getPoaConsensus.call()
@@ -250,7 +250,7 @@ contract('ProxyStorage [all features]', function (accounts) {
       let validatorMetadataNew = await ValidatorMetadata.new();
       
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(7, validatorMetadataNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(7, validatorMetadataNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getValidatorMetadata.call();
@@ -265,7 +265,7 @@ contract('ProxyStorage [all features]', function (accounts) {
       const newVersion = oldVersion.add(1);
       let proxyStorageNew = await ProxyStorageMock.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(8, proxyStorageNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(8, proxyStorageNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       proxyStorageNew.address.should.be.equal(
@@ -284,14 +284,14 @@ contract('ProxyStorage [all features]', function (accounts) {
     })
   })
   describe('#upgradeTo', async () => {
-    it('may be called only by ProxyStorage (itself)', async () => {
+    it('may only be called by ProxyStorage (itself)', async () => {
       const proxyStorageNew = await ProxyStorageNew.new();
       (await proxyStorageEternalStorage.getProxyStorage.call()).should.be.equal(
         proxyStorageEternalStorage.address
       );
       await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[0]}).should.be.rejectedWith(ERROR_MSG);
       await proxyStorageEternalStorage.setProxyStorage(accounts[0]);
-      await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[0]}).should.be.fulfilled;
+      await upgradeTo(proxyStorageNew.address, {from: accounts[0]});
       (await proxyStorageEternalStorage.implementation.call()).should.be.equal(
         proxyStorageNew.address
       );
@@ -299,7 +299,7 @@ contract('ProxyStorage [all features]', function (accounts) {
     it('should change implementation address', async () => {
       const proxyStorageNew = await ProxyStorageNew.new();
       await proxyStorageEternalStorage.setProxyStorage(accounts[0]);
-      await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[0]}).should.be.fulfilled;
+      await upgradeTo(proxyStorageNew.address, {from: accounts[0]});
       await proxyStorageEternalStorage.setProxyStorage(proxyStorageEternalStorage.address);
       (await proxyStorageEternalStorage.implementation.call()).should.be.equal(
         proxyStorageNew.address
@@ -311,7 +311,7 @@ contract('ProxyStorage [all features]', function (accounts) {
       const newVersion = oldVersion.add(1);
       (await proxyStorageEternalStorage.version.call()).should.be.bignumber.equal(oldVersion);
       await proxyStorageEternalStorage.setProxyStorage(accounts[0]);
-      await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[0]}).should.be.fulfilled;
+      await upgradeTo(proxyStorageNew.address, {from: accounts[0]});
       await proxyStorageEternalStorage.setProxyStorage(proxyStorageEternalStorage.address);
       proxyStorageNew = await ProxyStorageNew.at(proxyStorageEternalStorage.address);
       (await proxyStorageNew.version.call()).should.be.bignumber.equal(newVersion);
@@ -320,7 +320,7 @@ contract('ProxyStorage [all features]', function (accounts) {
     it('new implementation should work', async () => {
       let proxyStorageNew = await ProxyStorageNew.new();
       await proxyStorageEternalStorage.setProxyStorage(accounts[0]);
-      await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[0]}).should.be.fulfilled;
+      await upgradeTo(proxyStorageNew.address, {from: accounts[0]});
       await proxyStorageEternalStorage.setProxyStorage(proxyStorageEternalStorage.address);
       proxyStorageNew = await ProxyStorageNew.at(proxyStorageEternalStorage.address);
       (await proxyStorageNew.initialized.call()).should.be.equal(false);
@@ -330,10 +330,24 @@ contract('ProxyStorage [all features]', function (accounts) {
     it('new implementation should use the same storage', async () => {
       let proxyStorageNew = await ProxyStorageNew.new();
       await proxyStorageEternalStorage.setProxyStorage(accounts[0]);
-      await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[0]}).should.be.fulfilled;
+      await upgradeTo(proxyStorageNew.address, {from: accounts[0]});
       await proxyStorageEternalStorage.setProxyStorage(proxyStorageEternalStorage.address);
       proxyStorageNew = await ProxyStorageNew.at(proxyStorageEternalStorage.address);
       (await proxyStorageNew.getPoaConsensus.call()).should.be.equal(poaNetworkConsensus.address);
     });
   });
 })
+
+async function setContractAddress(_contractType, _contractAddress, _shouldBeSuccessful, options) {
+  const result = await proxyStorage.setContractAddress(_contractType, _contractAddress, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("AddressSet");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}
+
+async function upgradeTo(implementation, options) {
+  const {logs} = await proxyStorageEternalStorage.upgradeTo(implementation, options);
+  logs[0].event.should.be.equal("Upgraded");
+}

--- a/test/proxy_storage_upgrade_test.js
+++ b/test/proxy_storage_upgrade_test.js
@@ -41,11 +41,12 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
 
     const proxyStorageNew = await ProxyStorageNew.new();
     await proxyStorageEternalStorage.setProxyStorage(accounts[6]);
-    await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[6]});
+    const {logs} = await proxyStorageEternalStorage.upgradeTo(proxyStorageNew.address, {from: accounts[6]});
+    logs[0].event.should.be.equal("Upgraded");
     await proxyStorageEternalStorage.setProxyStorage(proxyStorageEternalStorage.address);
     proxyStorage = await ProxyStorageNew.at(proxyStorageEternalStorage.address);
 
-	keysManager = await KeysManager.new();
+    keysManager = await KeysManager.new();
     keysManagerEternalStorage = await EternalStorageProxy.new(proxyStorage.address, keysManager.address);
     keysManager = await KeysManager.at(keysManagerEternalStorage.address);
 
@@ -180,18 +181,18 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
     it('can only be called from votingToChangeProxy address', async () => {
       await proxyStorage.setContractAddress(1, accounts[2], {from: accounts[0]}).should.be.rejectedWith(ERROR_MSG);
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(1, accounts[2], {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(1, accounts[2], true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
     })
     it('cannot be set to 0x0 address', async () => {
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(1, '0x0000000000000000000000000000000000000000', {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
+      await setContractAddress(1, '0x0000000000000000000000000000000000000000', false, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
     })
     it('sets keysManager', async () => {
       let keysManagerNew = await KeysManager.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(1, keysManagerNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(1, keysManagerNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getKeysManager.call();
@@ -204,7 +205,7 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
     it('sets votingToChangeKeys', async () => {
       let votingToChangeKeysNew = await VotingToChangeKeys.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(2, votingToChangeKeysNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(2, votingToChangeKeysNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getVotingToChangeKeys.call();
@@ -217,7 +218,7 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
     it('sets votingToChangeMinThreshold', async () => {
       let votingToChangeMinThresholdNew = await VotingToChangeMinThreshold.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(3, votingToChangeMinThresholdNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(3, votingToChangeMinThresholdNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getVotingToChangeMinThreshold.call();
@@ -234,7 +235,7 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
       let ballotsStorageNew = await BallotsStorage.new();
 
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(5, ballotsStorageNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(5, ballotsStorageNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getBallotsStorage.call();
@@ -246,7 +247,7 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
     })
     it('sets poaConsensus', async () => {
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(6, accounts[5], {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(6, accounts[5], true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       accounts[5].should.be.equal(
         await proxyStorage.getPoaConsensus.call()
@@ -256,7 +257,7 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
       let validatorMetadataNew = await ValidatorMetadata.new();
       
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(7, validatorMetadataNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(7, validatorMetadataNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       let eternalProxyAddress = await proxyStorage.getValidatorMetadata.call();
@@ -271,7 +272,7 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
       const newVersion = oldVersion.add(1);
       let proxyStorageNew = await ProxyStorageMock.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
-      await proxyStorage.setContractAddress(8, proxyStorageNew.address, {from: accounts[4]}).should.be.fulfilled;
+      await setContractAddress(8, proxyStorageNew.address, true, {from: accounts[4]});
       await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
       
       proxyStorageNew.address.should.be.equal(
@@ -290,3 +291,12 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
     })
   })
 })
+
+async function setContractAddress(_contractType, _contractAddress, _shouldBeSuccessful, options) {
+  const result = await proxyStorage.setContractAddress(_contractType, _contractAddress, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("AddressSet");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -8,7 +8,8 @@ async function addValidators({
   arrayOfAddresses = arrayOfAddresses || arrayOfHundredAddresses;
   await proxyStorageMock.setVotingContractMock(masterOfCeremony);
   for(let validator of arrayOfAddresses){
-    await keysManager.addMiningKey(validator).should.be.fulfilled;
+    const {logs} = await keysManager.addMiningKey(validator);
+    logs[0].event.should.be.equal("MiningKeyChanged");
   }
   await poaNetworkConsensusMock.setSystemAddress(masterOfCeremony);
   await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;

--- a/test/voting_to_change_min_threshold_upgrade_test.js
+++ b/test/voting_to_change_min_threshold_upgrade_test.js
@@ -4,7 +4,7 @@ let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
 let Voting = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
 let VotingNew = artifacts.require('./upgradeContracts/VotingToChangeMinThresholdNew');
 let VotingForKeys = artifacts.require('./mockContracts/VotingToChangeKeysMock');
-let BallotsStorage = artifacts.require('./BallotsStorage');
+let BallotsStorage = artifacts.require('./mockContracts/BallotsStorageMock');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const moment = require('moment');
@@ -20,7 +20,7 @@ require('chai')
   .use(require('chai-bignumber')(web3.BigNumber))
   .should();
 
-let keysManager, poaNetworkConsensusMock, ballotsStorage, voting;
+let keysManager, poaNetworkConsensusMock, ballotsStorage, voting, votingEternalStorage;
 let votingKey, votingKey2, votingKey3, miningKeyForVotingKey;
 let VOTING_START_DATE, VOTING_END_DATE;
 contract('VotingToChangeMinThreshold upgraded [all features]', function (accounts) {
@@ -51,14 +51,15 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     
     voting = await Voting.new();
-    const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
+    votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
     voting = await Voting.at(votingEternalStorage.address);
     await voting.init(172800, 0).should.be.rejectedWith(ERROR_MSG);
     await voting.init(172800, 3).should.be.fulfilled;
 
     const votingNew = await VotingNew.new();
     await votingEternalStorage.setProxyStorage(accounts[6]);
-    await votingEternalStorage.upgradeTo(votingNew.address, {from: accounts[6]});
+    const {logs} = await votingEternalStorage.upgradeTo(votingNew.address, {from: accounts[6]});
+    logs[0].event.should.be.equal("Upgraded");
     await votingEternalStorage.setProxyStorage(proxyStorageMock.address);
     voting = await VotingNew.at(votingEternalStorage.address);
     
@@ -77,18 +78,18 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     await ballotsStorage.init([3, 2]).should.be.fulfilled;
 
     await proxyStorageMock.setVotingContractMock(accounts[0]);
-    await keysManager.addMiningKey(accounts[1]).should.be.fulfilled;
-    await keysManager.addVotingKey(votingKey, accounts[1]).should.be.fulfilled;
+    await addMiningKey(miningKeyForVotingKey);
+    await addVotingKey(votingKey, miningKeyForVotingKey);
 
-    await keysManager.addMiningKey(accounts[2]).should.be.fulfilled;
-    await keysManager.addVotingKey(votingKey2, accounts[2]).should.be.fulfilled;
+    await addMiningKey(accounts[2]);
+    await addVotingKey(votingKey2, accounts[2]);
 
-    await keysManager.addMiningKey(accounts[4]).should.be.fulfilled;
-    await keysManager.addVotingKey(votingKey3, accounts[4]).should.be.fulfilled;
+    await addMiningKey(accounts[4]);
+    await addVotingKey(votingKey3, accounts[4]);
 
-    await keysManager.addMiningKey(accounts[7]).should.be.fulfilled;
-    await keysManager.addMiningKey(accounts[8]).should.be.fulfilled;
-    await keysManager.addMiningKey(accounts[9]).should.be.fulfilled;
+    await addMiningKey(accounts[7]);
+    await addMiningKey(accounts[8]);
+    await addMiningKey(accounts[9]);
 
     await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
     await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
@@ -103,20 +104,26 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     })
     it('happy path', async () => {
       const {logs} = await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, 4, "memo", {from: votingKey});
-      const startTime = await voting.getStartTime.call(id.toNumber());
-      const endTime = await voting.getEndTime.call(id.toNumber());
       const keysManagerFromContract = await voting.getKeysManager.call();
-      startTime.should.be.bignumber.equal(VOTING_START_DATE);
-      endTime.should.be.bignumber.equal(VOTING_END_DATE);
-      (await voting.getTotalVoters.call(id)).should.be.bignumber.equal(0);
-      (await voting.getProgress.call(id)).should.be.bignumber.equal(0);
-      (await voting.getIsFinalized.call(id)).should.be.equal(false);
+      const ballotInfo = await voting.getBallotInfo.call(id, votingKey);
+
+      ballotInfo.should.be.deep.equal([
+        new web3.BigNumber(VOTING_START_DATE), // startTime
+        new web3.BigNumber(VOTING_END_DATE), // endTime
+        new web3.BigNumber(0), // totalVoters
+        new web3.BigNumber(0), // progress
+        false, // isFinalized
+        new web3.BigNumber(4), // proposedValue
+        miningKeyForVotingKey, // creator
+        "memo", // memo
+        false, // canBeFinalizedNow
+        false // hasAlreadyVoted
+      ]);
+
       (await voting.getQuorumState.call(id)).should.be.bignumber.equal(1);
       (await voting.getIndex.call(id)).should.be.bignumber.equal(0);
       (await voting.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(3);
-      (await voting.getProposedValue.call(id)).should.be.bignumber.equal(4);
-      (await voting.getCreator.call(id)).should.be.equal(miningKeyForVotingKey);
-      (await voting.getMemo.call(id)).should.be.equal("memo");
+
       keysManagerFromContract.should.be.equal(keysManager.address);
       logs[0].event.should.be.equal("BallotCreated");
       logs[0].args.id.should.be.bignumber.equal(0);
@@ -155,7 +162,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     it('should let a validator to vote', async () => {
       await voting.setTime(VOTING_START_DATE);
       const {logs} = await voting.vote(id, choice.accept, {from: votingKey}).should.be.fulfilled;
-      let progress = await voting.getProgress.call(id);
+      let progress = (await voting.getBallotInfo.call(id, votingKey))[3];
       progress.should.be.bignumber.equal(1);
       let totalVoters = await voting.getTotalVoters.call(id);
       totalVoters.should.be.bignumber.equal(1);
@@ -168,7 +175,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     it('reject vote should be accepted', async () => {
       await voting.setTime(VOTING_START_DATE);
       const {logs} = await voting.vote(id, choice.reject, {from: votingKey}).should.be.fulfilled;
-      let progress = await voting.getProgress.call(id);
+      let progress = (await voting.getBallotInfo.call(id, votingKey))[3];
       progress.should.be.bignumber.equal(-1);
       let totalVoters = await voting.getTotalVoters.call(id);
       totalVoters.should.be.bignumber.equal(1);
@@ -186,7 +193,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       // add new voter
       await voting.vote(id, choice.reject, {from: votingKey2}).should.be.fulfilled;
 
-      let progress = await voting.getProgress.call(id);
+      let progress = (await voting.getBallotInfo.call(id, votingKey))[3];
       progress.should.be.bignumber.equal(-2);
 
       let totalVoters = await voting.getTotalVoters.call(id);
@@ -194,7 +201,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
 
       await voting.vote(id, choice.accept, {from: votingKey3}).should.be.fulfilled;
 
-      progress = await voting.getProgress.call(id);
+      progress = (await voting.getBallotInfo.call(id, votingKey))[3];
       progress.should.be.bignumber.equal(-1);
 
       totalVoters = await voting.getTotalVoters.call(id);
@@ -246,28 +253,32 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await voting.vote(votingId, choice.accept, {from: votingKey}).should.be.fulfilled;
       // await voting.vote(votingId, choice.accept, {from: votingKey2}).should.be.fulfilled;
       await voting.setTime(VOTING_END_DATE + 1);
-      const {logs} = await voting.finalize(votingId, {from: votingKey}).should.be.fulfilled;
+      const {logs} = await voting.finalize(votingId, {from: votingKey});
       activeBallotsLength = await voting.activeBallotsLength.call();
       activeBallotsLength.should.be.bignumber.equal(0);
-      true.should.be.equal(await voting.getIsFinalized.call(votingId));
+      true.should.be.equal((await voting.getBallotInfo.call(votingId, votingKey))[4]); // isFinalized
       // Finalized(msg.sender);
       logs[0].event.should.be.equal("BallotFinalized");
       logs[0].args.voter.should.be.equal(votingKey);
-      (await voting.getStartTime.call(votingId)).should.be.bignumber.equal(VOTING_START_DATE);
-      (await voting.getEndTime.call(votingId)).should.be.bignumber.equal(VOTING_END_DATE);
-      (await voting.getTotalVoters.call(votingId)).should.be.bignumber.equal(1);
-      (await voting.getProgress.call(votingId)).should.be.bignumber.equal(1);
-      (await voting.getIsFinalized.call(votingId)).should.be.equal(true);
+
+      const ballotInfo = await voting.getBallotInfo.call(votingId, votingKey);
+
+      ballotInfo.should.be.deep.equal([
+        new web3.BigNumber(VOTING_START_DATE), // startTime
+        new web3.BigNumber(VOTING_END_DATE), // endTime
+        new web3.BigNumber(1), // totalVoters
+        new web3.BigNumber(1), // progress
+        true, // isFinalized
+        new web3.BigNumber(proposedValue), // proposedValue
+        miningKeyForVotingKey, // creator
+        "memo", // memo
+        false, // canBeFinalizedNow
+        true // hasAlreadyVoted
+      ]);
+
       (await voting.getQuorumState.call(votingId)).should.be.bignumber.equal(3);
       (await voting.getIndex.call(votingId)).should.be.bignumber.equal(0);
       (await voting.getMinThresholdOfVoters.call(votingId)).should.be.bignumber.equal(3);
-      (await voting.getProposedValue.call(votingId)).should.be.bignumber.equal(proposedValue);
-      (await voting.getCreator.call(votingId)).should.be.equal(miningKeyForVotingKey);
-      (await voting.getMemo.call(votingId)).should.be.equal("memo");
-
-      true.should.be.equal(
-        await voting.hasAlreadyVoted.call(votingId, votingKey)
-      );
 
       const minThresholdOfVoters = await ballotsStorage.getBallotThreshold.call(1);
       minThresholdOfVoters.should.be.bignumber.equal(3);
@@ -284,30 +295,34 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await voting.vote(votingId, choice.accept, {from: votingKey2}).should.be.fulfilled;
       await voting.vote(votingId, choice.reject, {from: votingKey3}).should.be.fulfilled;
       await voting.setTime(VOTING_END_DATE + 1);
-      const {logs} = await voting.finalize(votingId, {from: votingKey}).should.be.fulfilled;
+      const {logs} = await voting.finalize(votingId, {from: votingKey});
 
       activeBallotsLength = await voting.activeBallotsLength.call();
       activeBallotsLength.should.be.bignumber.equal(0);
-      true.should.be.equal(await voting.getIsFinalized.call(votingId));
+      true.should.be.equal((await voting.getBallotInfo.call(votingId, votingKey))[4]); // isFinalized
       // Finalized(msg.sender);
       logs[0].event.should.be.equal("BallotFinalized");
       logs[0].args.voter.should.be.equal(votingKey);
 
-      (await voting.getStartTime.call(votingId)).should.be.bignumber.equal(VOTING_START_DATE);
-      (await voting.getEndTime.call(votingId)).should.be.bignumber.equal(VOTING_END_DATE);
-      (await voting.getTotalVoters.call(votingId)).should.be.bignumber.equal(3);
-      (await voting.getProgress.call(votingId)).should.be.bignumber.equal(1);
-      (await voting.getIsFinalized.call(votingId)).should.be.equal(true);
+      const ballotInfo = await voting.getBallotInfo.call(votingId, votingKey);
+
+      ballotInfo.should.be.deep.equal([
+        new web3.BigNumber(VOTING_START_DATE), // startTime
+        new web3.BigNumber(VOTING_END_DATE), // endTime
+        new web3.BigNumber(3), // totalVoters
+        new web3.BigNumber(1), // progress
+        true, // isFinalized
+        new web3.BigNumber(proposedValue), // proposedValue
+        miningKeyForVotingKey, // creator
+        "memo", // memo
+        false, // canBeFinalizedNow
+        true // hasAlreadyVoted
+      ]);
+
       (await voting.getQuorumState.call(votingId)).should.be.bignumber.equal(2);
       (await voting.getIndex.call(votingId)).should.be.bignumber.equal(0);
       (await voting.getMinThresholdOfVoters.call(votingId)).should.be.bignumber.equal(3);
-      (await voting.getProposedValue.call(votingId)).should.be.bignumber.equal(proposedValue);
-      (await voting.getCreator.call(votingId)).should.be.equal(miningKeyForVotingKey);
-      (await voting.getMemo.call(votingId)).should.be.equal("memo");
 
-      true.should.be.equal(
-        await voting.hasAlreadyVoted.call(votingId, votingKey)
-      );
       true.should.be.equal(
         await voting.hasAlreadyVoted.call(votingId, votingKey2)
       );
@@ -335,8 +350,8 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, proposedValue1, "memo",{from: votingKey});
 
       await proxyStorageMock.setVotingContractMock(accounts[0]);
-      await keysManager.addMiningKey("0xa6Bf70bd230867c870eF13631D7EFf1AE8Ab85c9").should.be.fulfilled;
-      await keysManager.addMiningKey("0xa6Bf70bd230867c870eF13631D7EFf1AE8Ab85d9").should.be.fulfilled;
+      await addMiningKey("0xa6Bf70bd230867c870eF13631D7EFf1AE8Ab85c9");
+      await addMiningKey("0xa6Bf70bd230867c870eF13631D7EFf1AE8Ab85d9");
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
 
@@ -351,27 +366,30 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await voting.vote(votingId, choice.accept, {from: votingKey2}).should.be.fulfilled;
       await voting.vote(votingId, choice.accept, {from: votingKey3}).should.be.fulfilled;
       await voting.setTime(VOTING_END_DATE + 1);
-      false.should.be.equal(await voting.getIsFinalized.call(votingId));
-      await voting.finalize(votingId, {from: votingKey}).should.be.fulfilled;
+      false.should.be.equal((await voting.getBallotInfo.call(votingId, votingKey))[4]); // isFinalized
+      await finalize(votingId, true, {from: votingKey});
       await voting.vote(votingId, choice.accept, { from: votingKey }).should.be.rejectedWith(ERROR_MSG);
       new web3.BigNumber(4).should.be.bignumber.equal(await voting.getProposedValue.call(votingId));
-      true.should.be.equal(await voting.getIsFinalized.call(votingId));
+      true.should.be.equal((await voting.getBallotInfo.call(votingId, votingKey))[4]); // isFinalized
       await voting.finalize(votingId, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
       await voting.finalize(votingIdForSecond, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
       new web3.BigNumber(5).should.be.bignumber.equal(await voting.getProposedValue.call(votingIdForSecond));
-      false.should.be.equal(await voting.getIsFinalized.call(votingIdForSecond));
+      false.should.be.equal((await voting.getBallotInfo.call(votingIdForSecond, votingKey))[4]); // isFinalized
       await voting.vote(votingIdForSecond, choice.reject, {from: votingKey}).should.be.fulfilled;
       await voting.setTime(VOTING_END_DATE + 3);
-      await voting.finalize(votingIdForSecond, {from: votingKey}).should.be.fulfilled;
+      await finalize(votingIdForSecond, true, {from: votingKey});
 
-      new web3.BigNumber(-1).should.be.bignumber.equal(await voting.getProgress.call(votingIdForSecond))
-      new web3.BigNumber(1).should.be.bignumber.equal(await voting.getProgress.call(votingId))
+      new web3.BigNumber(-1).should.be.bignumber.equal((await voting.getBallotInfo.call(votingIdForSecond, votingKey))[3]) // progress
+      new web3.BigNumber(1).should.be.bignumber.equal((await voting.getBallotInfo.call(votingId, votingKey))[3]) // progress
     });
 
     it('allowed at once after all validators gave their votes', async () => {
-      await keysManager.removeMiningKey(accounts[7]).should.be.fulfilled;
-      await keysManager.removeMiningKey(accounts[8]).should.be.fulfilled;
-      await keysManager.removeMiningKey(accounts[9]).should.be.fulfilled;
+      let result = await keysManager.removeMiningKey(accounts[7]);
+      result.logs[0].event.should.equal("MiningKeyChanged");
+      result = await keysManager.removeMiningKey(accounts[8]);
+      result.logs[0].event.should.equal("MiningKeyChanged");
+      result = await keysManager.removeMiningKey(accounts[9]);
+      result.logs[0].event.should.equal("MiningKeyChanged");
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
 
       await voting.setMinPossibleThreshold(2);
@@ -383,7 +401,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
         {from: votingKey3}
       ).should.be.fulfilled;
 
-      (await voting.getIsFinalized.call(0)).should.be.equal(false);
+      false.should.be.equal((await voting.getBallotInfo.call(0, votingKey3))[4]); // isFinalized
 
       await voting.setTime(VOTING_START_DATE);
       await voting.vote(0, choice.reject, {from: votingKey}).should.be.fulfilled;
@@ -393,13 +411,13 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await voting.setTime(VOTING_START_DATE+1);
       await voting.finalize(0, {from: votingKey2}).should.be.rejectedWith(ERROR_MSG);
 
-      (await voting.getIsFinalized.call(0)).should.be.equal(false);
+      false.should.be.equal((await voting.getBallotInfo.call(0, votingKey2))[4]); // isFinalized
 
       await voting.setTime(VOTING_START_DATE+172800+1);
       (await voting.getTime.call()).should.be.bignumber.below(VOTING_END_DATE);
-      await voting.finalize(0, {from: votingKey2}).should.be.fulfilled;
+      await finalize(0, true, {from: votingKey2});
 
-      (await voting.getIsFinalized.call(0)).should.be.equal(true);
+      true.should.be.equal((await voting.getBallotInfo.call(0, votingKey2))[4]); // isFinalized
 
       await voting.setTime(VOTING_END_DATE+1);
       await voting.finalize(0, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
@@ -415,7 +433,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
         {from: votingKey3}
       ).should.be.fulfilled;
 
-      (await voting.getIsFinalized.call(1)).should.be.equal(false);
+      false.should.be.equal((await voting.getBallotInfo.call(1, votingKey3))[4]); // isFinalized
 
       await voting.setTime(VOTING_START_DATE);
       await voting.vote(1, choice.reject, {from: votingKey}).should.be.fulfilled;
@@ -425,11 +443,56 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       (await voting.getTime.call()).should.be.bignumber.below(VOTING_END_DATE);
       await voting.finalize(1, {from: votingKey2}).should.be.rejectedWith(ERROR_MSG);
 
-      (await voting.getIsFinalized.call(1)).should.be.equal(false);
+      false.should.be.equal((await voting.getBallotInfo.call(1, votingKey2))[4]); // isFinalized
 
       await voting.setTime(VOTING_END_DATE+1);
-      await voting.finalize(1, {from: votingKey2}).should.be.fulfilled;
-      (await voting.getIsFinalized.call(1)).should.be.equal(true);
+      await finalize(1, true, {from: votingKey2});
+      true.should.be.equal((await voting.getBallotInfo.call(1, votingKey2))[4]); // isFinalized
+    });
+
+    it('should decrease validator limit only once when calling finalize more than once', async () => {
+      let result = await keysManager.removeMiningKey(accounts[7]);
+      result.logs[0].event.should.equal("MiningKeyChanged");
+      result = await keysManager.removeMiningKey(accounts[8]);
+      result.logs[0].event.should.equal("MiningKeyChanged");
+      result = await keysManager.removeMiningKey(accounts[9]);
+      result.logs[0].event.should.equal("MiningKeyChanged");
+      await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
+
+      await voting.setMinPossibleThreshold(2);
+      await ballotsStorage.setThresholdMock(1, 1);
+
+      votingId = await voting.nextBallotId.call();
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, 2, "memo", {from: votingKey});
+      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, 2, "memo", {from: votingKey});
+      (await voting.validatorActiveBallots.call(miningKeyForVotingKey)).should.be.bignumber.equal(2);
+      
+      await voting.setTime(VOTING_START_DATE);
+      await voting.vote(votingId, choice.accept, {from: votingKey}).should.be.fulfilled;
+      await voting.vote(votingId, choice.accept, {from: votingKey2}).should.be.fulfilled;
+
+      await ballotsStorage.setThresholdMock(2, 1);
+      await voting.setTime(VOTING_END_DATE + 1);
+
+      result = await voting.finalize(votingId, {from: votingKey});
+      result.logs.length.should.be.equal(0);
+      (await voting.validatorActiveBallots.call(miningKeyForVotingKey)).should.be.bignumber.equal(1);
+      (await voting.getIsFinalized.call(votingId)).should.be.equal(false);
+      (await voting.getQuorumState.call(votingId)).should.be.bignumber.equal(1);
+
+      result = await voting.finalize(votingId, {from: votingKey});
+      result.logs.length.should.be.equal(0);
+      (await voting.validatorActiveBallots.call(miningKeyForVotingKey)).should.be.bignumber.equal(1);
+      (await voting.getIsFinalized.call(votingId)).should.be.equal(false);
+      (await voting.getQuorumState.call(votingId)).should.be.bignumber.equal(1);
+
+      await ballotsStorage.setThresholdMock(1, 1);
+
+      result = await voting.finalize(votingId, {from: votingKey});
+      result.logs[0].event.should.equal("BallotFinalized");
+      (await voting.validatorActiveBallots.call(miningKeyForVotingKey)).should.be.bignumber.equal(1);
+      (await voting.getIsFinalized.call(votingId)).should.be.equal(true);
+      (await voting.getQuorumState.call(votingId)).should.be.bignumber.equal(2);
     });
   });
 
@@ -441,30 +504,40 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, 4, "memo", {from: votingKey}).should.be.fulfilled;
 
       let votingNew = await Voting.new();
-      const votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
+      votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
       votingNew = await Voting.at(votingEternalStorage.address);
+
+      let ballotInfo = await voting.getBallotInfo.call(id, votingKey);
 
       await votingNew.migrateBasicOne(
         id,
         voting.address,
         await voting.getQuorumState.call(id),
         await voting.getIndex.call(id),
-        await voting.getCreator.call(id),
-        await voting.getMemo.call(id),
+        ballotInfo[6], // creator
+        ballotInfo[7], // memo
         [votingKey, votingKey2, votingKey3]
       );
 
-      (await votingNew.getStartTime.call(id)).should.be.bignumber.equal(VOTING_START_DATE);
-      (await votingNew.getEndTime.call(id)).should.be.bignumber.equal(VOTING_END_DATE);
-      (await votingNew.getTotalVoters.call(id)).should.be.bignumber.equal(0);
-      (await votingNew.getProgress.call(id)).should.be.bignumber.equal(0);
-      (await votingNew.getIsFinalized.call(id)).should.be.equal(false);
+      ballotInfo = await votingNew.getBallotInfo.call(id, votingKey);
+
+      ballotInfo.should.be.deep.equal([
+        new web3.BigNumber(VOTING_START_DATE), // startTime
+        new web3.BigNumber(VOTING_END_DATE), // endTime
+        new web3.BigNumber(0), // totalVoters
+        new web3.BigNumber(0), // progress
+        false, // isFinalized
+        new web3.BigNumber(4), // proposedValue
+        accounts[1], // creator
+        "memo", // memo
+        false, // canBeFinalizedNow
+        false // hasAlreadyVoted
+      ]);
+
       (await votingNew.getQuorumState.call(id)).should.be.bignumber.equal(1);
       (await votingNew.getIndex.call(id)).should.be.bignumber.equal(0);
       (await votingNew.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(3);
-      (await votingNew.getCreator.call(id)).should.be.equal(accounts[1]);
-      (await votingNew.getMemo.call(id)).should.be.equal("memo");
-      (await votingNew.getProposedValue.call(id)).should.be.bignumber.equal(4);
+
       (await votingNew.hasMiningKeyAlreadyVoted.call(id, votingKey)).should.be.equal(true);
       (await votingNew.hasMiningKeyAlreadyVoted.call(id, votingKey2)).should.be.equal(true);
       (await votingNew.hasMiningKeyAlreadyVoted.call(id, votingKey3)).should.be.equal(true);
@@ -487,3 +560,22 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     });
   });
 })
+
+async function addMiningKey(_key) {
+  const {logs} = await keysManager.addMiningKey(_key);
+  logs[0].event.should.be.equal("MiningKeyChanged");
+}
+
+async function addVotingKey(_key, _miningKey) {
+  const {logs} = await keysManager.addVotingKey(_key, _miningKey);
+  logs[0].event.should.be.equal("VotingKeyChanged");
+}
+
+async function finalize(_id, _shouldBeSuccessful, options) {
+  const result = await voting.finalize(_id, options);
+  if (_shouldBeSuccessful) {
+    result.logs[0].event.should.be.equal("BallotFinalized");
+  } else {
+    result.logs.length.should.be.equal(0);
+  }
+}


### PR DESCRIPTION
**(Mandatory) Description**
- Reverts have been removed from ballots finalization to prevent deadlocking of `finalize` function when some conditions are changed - now `_decreaseValidatorLimit` internal function can be called once even when a ballot cannot be finalized.
- `VotingToChange*` contracts have been optimized to reduce gas spending when deploying them:
a few excess public getters have been removed;
the functions `areBallotParamsValid` and `checkIfMiningExisted` have been moved to `BallotsStorage` and `KeysManager` contracts, respectively.
- Unit tests have been corrected for rechecking and satisfying the changes described above.

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Fix)