### PR TITLE
(Fix) PoaNetworkConsensus contract and KeysManager.migrateMiningKey function

### DIFF
--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -204,8 +204,7 @@ contract KeysManager is EternalStorage, IKeysManager {
     }
 
     function migrateMiningKey(
-        address _miningKey,
-        uint8 _maxMiningKeyHistoryDeep
+        address _miningKey
     ) public onlyOwner {
         require(previousKeysManager() != address(0));
         IKeysManager previous = IKeysManager(previousKeysManager());
@@ -224,7 +223,8 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setMiningKeyByPayout(payoutKey, _miningKey);
         _setSuccessfulValidatorClone(true, _miningKey);
         address currentMiningKey = _miningKey;
-        for (uint8 i = 0; i < _maxMiningKeyHistoryDeep; i++) {
+        uint8 maxMiningKeyHistoryDeep = maxOldMiningKeysDeepCheck();
+        for (uint8 i = 0; i < maxMiningKeyHistoryDeep; i++) {
             address oldMiningKey = previous.getMiningKeyHistory(currentMiningKey);
             if (oldMiningKey == 0) {
                 break;

--- a/contracts/PoaNetworkConsensus.sol
+++ b/contracts/PoaNetworkConsensus.sol
@@ -43,7 +43,7 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
     bool internal _isMoCRemovedPending = false;
 
     bool public finalized = false;
-    bool public isMasterOfCeremonyInitialized = false;
+    bool public wasProxyStorageSet = false;
 
     modifier onlySystemAndNotFinalized() {
         require(msg.sender == systemAddress && !finalized);
@@ -65,7 +65,9 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
             currentValidators.push(validators[y]);
         }
         for (uint256 i = 0; i < currentValidators.length; i++) {
-            validatorsState[currentValidators[i]] = ValidatorState({
+            address validator = currentValidators[i];
+            require(!validatorsState[validator].isValidator);
+            validatorsState[validator] = ValidatorState({
                 isValidator: true,
                 isValidatorFinalized: true,
                 index: i
@@ -166,10 +168,10 @@ contract PoaNetworkConsensus is IPoaNetworkConsensus {
     function setProxyStorage(address _newAddress) public {
         // any miner can change the address
         require(isValidator(msg.sender) || msg.sender == _owner);
-        require(!isMasterOfCeremonyInitialized);
+        require(!wasProxyStorageSet);
         require(_newAddress != address(0));
         proxyStorage = IProxyStorage(_newAddress);
-        isMasterOfCeremonyInitialized = true;
+        wasProxyStorageSet = true;
         emit MoCInitializedProxyStorage(proxyStorage);
     }
 

--- a/contracts/interfaces/IKeysManager.sol
+++ b/contracts/interfaces/IKeysManager.sol
@@ -8,7 +8,7 @@ interface IKeysManager {
     function createKeys(address, address, address) external;
     function initiateKeys(address) external;
     function migrateInitialKey(address) external;
-    function migrateMiningKey(address, uint8) external;
+    function migrateMiningKey(address) external;
     function removeMiningKey(address) external returns(bool);
     function removeVotingKey(address) external returns(bool);
     function removePayoutKey(address) external returns(bool);

--- a/scripts/migrate/migrateAll.js
+++ b/scripts/migrate/migrateAll.js
@@ -58,7 +58,7 @@ async function main() {
 
 		console.log('  PoaNetworkConsensus checking...');
 		false.should.be.equal(
-			await poaNewInstance.methods.isMasterOfCeremonyInitialized().call()
+			await poaNewInstance.methods.wasProxyStorageSet().call()
 		);
 		mocAddress.should.be.equal(
 			await poaNewInstance.methods.masterOfCeremony().call()
@@ -110,7 +110,7 @@ async function main() {
 			await proxyStorageInstance.methods.getPoaConsensus().call()
 		);
 		true.should.be.equal(
-			await poaNewInstance.methods.isMasterOfCeremonyInitialized().call()
+			await poaNewInstance.methods.wasProxyStorageSet().call()
 		);
 		process.env.PROXY_STORAGE_NEW_ADDRESS.should.be.equal(
 			await poaNewInstance.methods.proxyStorage().call()

--- a/scripts/migrate/migrateKeys.js
+++ b/scripts/migrate/migrateKeys.js
@@ -126,8 +126,8 @@ async function migrateAndCheck(privateKey) {
 			}
 
 			const votingForKeysOldInstance = new web3.eth.Contract(VOTING_TO_CHANGE_KEYS_OLD_ABI, VOTING_TO_CHANGE_KEYS_OLD_ADDRESS);
-			const maxOldMiningKeysDeepCheck = await votingForKeysOldInstance.methods.maxOldMiningKeysDeepCheck().call();
-			maxOldMiningKeysDeepCheck.should.be.bignumber.equal(25);
+			(await votingForKeysOldInstance.methods.maxOldMiningKeysDeepCheck().call()).should.be.bignumber.equal(25);
+			(await keysManagerNewInstance.methods.maxOldMiningKeysDeepCheck().call()).should.be.bignumber.equal(25);
 
 			console.log(`  Migrate each of ${miningKeys.length} mining key(s)...`);
 			for (let i = 0; i < miningKeys.length; i++) {
@@ -137,8 +137,7 @@ async function migrateAndCheck(privateKey) {
 					continue;
 				}
 				const migrateMiningKey = keysManagerNewInstance.methods.migrateMiningKey(
-					miningKey,
-					maxOldMiningKeysDeepCheck
+					miningKey
 				);
 				await utils.call(migrateMiningKey, sender, contractNewAddress, key, chainId);
 			}

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -764,15 +764,14 @@ contract('KeysManager [all features]', function (accounts) {
       
       // mining #1
       await newKeysManager.migrateMiningKey(
-        '0x0000000000000000000000000000000000000000',
-        25
+        '0x0000000000000000000000000000000000000000'
       ).should.be.rejectedWith(ERROR_MSG);
-      await newKeysManager.migrateMiningKey(accounts[9], 25).should.be.rejectedWith(ERROR_MSG);
-      let {logs} = await newKeysManager.migrateMiningKey(miningKey, 25).should.be.fulfilled;
+      await newKeysManager.migrateMiningKey(accounts[9]).should.be.rejectedWith(ERROR_MSG);
+      let {logs} = await newKeysManager.migrateMiningKey(miningKey).should.be.fulfilled;
       logs[0].event.should.equal("Migrated");
       logs[0].args.key.should.be.equal(miningKey);
       logs[0].args.name.should.be.equal("miningKey");
-      await newKeysManager.migrateMiningKey(miningKey, 25).should.be.rejectedWith(ERROR_MSG);
+      await newKeysManager.migrateMiningKey(miningKey).should.be.rejectedWith(ERROR_MSG);
 
       let initialKeys = await newKeysManager.initialKeysCount.call();
       initialKeys.should.be.bignumber.equal(1);
@@ -804,7 +803,7 @@ contract('KeysManager [all features]', function (accounts) {
       )
 
       // mining #2
-      await newKeysManager.migrateMiningKey(miningKey3, 25).should.be.fulfilled;
+      await newKeysManager.migrateMiningKey(miningKey3).should.be.fulfilled;
       const validatorKey2 = await newKeysManager.validatorKeys.call(miningKey3);
       validatorKey2.should.be.deep.equal([
         "0x0000000000000000000000000000000000000000",
@@ -835,7 +834,7 @@ contract('KeysManager [all features]', function (accounts) {
       true.should.be.equal(
         await newKeysManager.successfulValidatorClone.call(masterOfCeremony)
       );
-      await newKeysManager.migrateMiningKey(masterOfCeremony, 25).should.be.rejectedWith(ERROR_MSG);
+      await newKeysManager.migrateMiningKey(masterOfCeremony).should.be.rejectedWith(ERROR_MSG);
     })
   });
 

--- a/test/keys_manager_upgrade_test.js
+++ b/test/keys_manager_upgrade_test.js
@@ -771,15 +771,14 @@ contract('KeysManager upgraded [all features]', function (accounts) {
       
       // mining #1
       await newKeysManager.migrateMiningKey(
-        '0x0000000000000000000000000000000000000000',
-        25
+        '0x0000000000000000000000000000000000000000'
       ).should.be.rejectedWith(ERROR_MSG);
-      await newKeysManager.migrateMiningKey(accounts[9], 25).should.be.rejectedWith(ERROR_MSG);
-      let {logs} = await newKeysManager.migrateMiningKey(miningKey, 25).should.be.fulfilled;
+      await newKeysManager.migrateMiningKey(accounts[9]).should.be.rejectedWith(ERROR_MSG);
+      let {logs} = await newKeysManager.migrateMiningKey(miningKey).should.be.fulfilled;
       logs[0].event.should.equal("Migrated");
       logs[0].args.key.should.be.equal(miningKey);
       logs[0].args.name.should.be.equal("miningKey");
-      await newKeysManager.migrateMiningKey(miningKey, 25).should.be.rejectedWith(ERROR_MSG);
+      await newKeysManager.migrateMiningKey(miningKey).should.be.rejectedWith(ERROR_MSG);
 
       let initialKeys = await newKeysManager.initialKeysCount.call();
       initialKeys.should.be.bignumber.equal(1);
@@ -811,7 +810,7 @@ contract('KeysManager upgraded [all features]', function (accounts) {
       )
 
       // mining #2
-      await newKeysManager.migrateMiningKey(miningKey3, 25).should.be.fulfilled;
+      await newKeysManager.migrateMiningKey(miningKey3).should.be.fulfilled;
       const validatorKey2 = await newKeysManager.validatorKeys.call(miningKey3);
       validatorKey2.should.be.deep.equal([
         "0x0000000000000000000000000000000000000000",
@@ -842,7 +841,7 @@ contract('KeysManager upgraded [all features]', function (accounts) {
       true.should.be.equal(
         await newKeysManager.successfulValidatorClone.call(masterOfCeremony)
       );
-      await newKeysManager.migrateMiningKey(masterOfCeremony, 25).should.be.rejectedWith(ERROR_MSG);
+      await newKeysManager.migrateMiningKey(masterOfCeremony).should.be.rejectedWith(ERROR_MSG);
     })
   });
 });

--- a/test/mockContracts/PoaNetworkConsensusMock.sol
+++ b/test/mockContracts/PoaNetworkConsensusMock.sol
@@ -26,8 +26,8 @@ contract PoaNetworkConsensusMock is PoaNetworkConsensus {
         _moc = _newAddress;
     }
 
-    function setIsMasterOfCeremonyInitializedMock(bool _status) public {
-        isMasterOfCeremonyInitialized = _status;
+    function setWasProxyStorageSetMock(bool _status) public {
+        wasProxyStorageSet = _status;
     }
 
     function setCurrentValidatorsLength(uint256 _newNumber) public {

--- a/test/poa_network_consensus_test.js
+++ b/test/poa_network_consensus_test.js
@@ -50,15 +50,30 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
       let systemAddress = await poaNetworkConsensus.systemAddress.call();
       systemAddress.should.be.equal('0xfffffffffffffffffffffffffffffffffffffffe');
     })
+
     it('allows you to set current list of validators', async () => {
       let validatorsList = [accounts[2], accounts[3], accounts[4]];
-      let poa = await PoaNetworkConsensus.new(masterOfCeremony, validatorsList);
+      let poa = await PoaNetworkConsensus.new(masterOfCeremony, validatorsList).should.be.fulfilled;
       let validators = await poa.getValidators.call();
-      let finalized = await poa.finalized.call();
       validators.should.be.deep.equal([
         masterOfCeremony,
         ...validatorsList
       ]);
+    })
+
+    it('validators in the list must differ', async () => {
+      await PoaNetworkConsensus.new(
+        masterOfCeremony,
+        [masterOfCeremony, accounts[3], accounts[4]]
+      ).should.be.rejectedWith(ERROR_MSG);
+      await PoaNetworkConsensus.new(
+        masterOfCeremony,
+        [accounts[2], accounts[2], accounts[4]]
+      ).should.be.rejectedWith(ERROR_MSG);
+      await PoaNetworkConsensus.new(
+        masterOfCeremony,
+        [accounts[2], accounts[3], accounts[3]]
+      ).should.be.rejectedWith(ERROR_MSG);
     })
   })
 
@@ -308,7 +323,7 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
     const nonValidator = accounts[3];
     let validator = accounts[0];
     it('can be called by any validator', async () => {
-      await poaNetworkConsensus.setIsMasterOfCeremonyInitializedMock(false);
+      await poaNetworkConsensus.setWasProxyStorageSetMock(false);
       await poaNetworkConsensus.setProxyStorage(nonValidator, {from: accounts[6]}).should.be.rejectedWith(ERROR_MSG);
       await poaNetworkConsensus.setProxyStorage(accounts[5], {from: validator}).should.be.fulfilled;
     })
@@ -317,32 +332,32 @@ contract('PoaNetworkConsensus [all features]', function (accounts) {
       await poaNetworkConsensus.setProxyStorage(nonValidator, {from: nonValidator}).should.be.rejectedWith(ERROR_MSG);
     })
     it('cannot be set to 0x0 address', async () => {
-      await poaNetworkConsensus.setIsMasterOfCeremonyInitializedMock(false);
+      await poaNetworkConsensus.setWasProxyStorageSetMock(false);
       await poaNetworkConsensus.setProxyStorage('0x0000000000000000000000000000000000000000', {from: validator}).should.be.rejectedWith(ERROR_MSG);
     })
     it('sets proxyStorage', async () => {
       let newProxyStorage = accounts[3];
-      await poaNetworkConsensus.setIsMasterOfCeremonyInitializedMock(false);
+      await poaNetworkConsensus.setWasProxyStorageSetMock(false);
       await poaNetworkConsensus.setProxyStorage(newProxyStorage, {from: validator}).should.be.fulfilled;
       (await poaNetworkConsensus.proxyStorage.call()).should.be.equal(newProxyStorage);
     })
-    it('sets isMasterOfCeremonyInitialized', async () => {
+    it('sets wasProxyStorageSet', async () => {
       let newProxyStorage = accounts[3];
-      await poaNetworkConsensus.setIsMasterOfCeremonyInitializedMock(false);
+      await poaNetworkConsensus.setWasProxyStorageSetMock(false);
       await poaNetworkConsensus.setProxyStorage(newProxyStorage, {from: validator}).should.be.fulfilled;
-      (await poaNetworkConsensus.isMasterOfCeremonyInitialized.call()).should.be.equal(true);
+      (await poaNetworkConsensus.wasProxyStorageSet.call()).should.be.equal(true);
     })
 
     it('emits MoCInitializedProxyStorage', async () => {
       let newProxyStorage = accounts[3];
-      await poaNetworkConsensus.setIsMasterOfCeremonyInitializedMock(false);
+      await poaNetworkConsensus.setWasProxyStorageSetMock(false);
       const {logs} = await poaNetworkConsensus.setProxyStorage(newProxyStorage, {from: validator}).should.be.fulfilled;
       logs[0].event.should.be.equal('MoCInitializedProxyStorage');
       logs[0].args.proxyStorage.should.be.equal(newProxyStorage);
     })
     it('#getKeysManager', async () => {
       let newKeysManager = accounts[3];
-      await poaNetworkConsensus.setIsMasterOfCeremonyInitializedMock(false);
+      await poaNetworkConsensus.setWasProxyStorageSetMock(false);
       await proxyStorageMock.setKeysManagerMock(newKeysManager);
       (await poaNetworkConsensus.getKeysManager.call()).should.be.equal(newKeysManager);
     })


### PR DESCRIPTION
**(Mandatory) Description**
- `PoaNetworkConsensus` constructor has been complemented with checking for keys duplication. 
- `PoaNetworkConsensus.isMasterOfCeremonyInitialized` boolean flag has been renamed to `wasProxyStorageSet`.
- `KeysManager.migrateMiningKey` function now uses `maxOldMiningKeysDeepCheck()` public getter instead of `_maxMiningKeyHistoryDeep` parameter.

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Fix)