### PR TITLE
(Fix) Add moveMetadata and clearMetadata functions to ValidatorMetadata contract

### DIFF
--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -4,6 +4,7 @@ import "./libs/SafeMath.sol";
 import "./interfaces/IPoaNetworkConsensus.sol";
 import "./interfaces/IKeysManager.sol";
 import "./interfaces/IProxyStorage.sol";
+import "./interfaces/IValidatorMetadata.sol";
 import "./eternal-storage/EternalStorage.sol";
 
 
@@ -397,6 +398,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setMiningKeyByVoting(votingKey, address(0));
         _setMiningKeyByPayout(payoutKey, address(0));
         _clearMiningKey(_key);
+        IValidatorMetadata(_getValidatorMetadata()).clearMetadata(_key);
         emit MiningKeyChanged(_key, "removed");
         if (votingKey != address(0)) {
             emit VotingKeyChanged(votingKey, _key, "removed");
@@ -444,6 +446,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         _clearMiningKey(_oldMiningKey);
         _setMiningKeyByVoting(votingKey, _key);
         _setMiningKeyByPayout(payoutKey, _key);
+        IValidatorMetadata(_getValidatorMetadata()).moveMetadata(_oldMiningKey, _key);
         emit MiningKeyChanged(_key, "swapped");
         return true;
     }
@@ -489,6 +492,10 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setIsMiningActive(false, _miningKey);
         _setIsVotingActive(false, _miningKey);
         _setIsPayoutActive(false, _miningKey);
+    }
+
+    function _getValidatorMetadata() private view returns(address) {
+        return IProxyStorage(proxyStorage()).getValidatorMetadata();
     }
 
     function _removeVotingKey(address _miningKey) private {

--- a/contracts/interfaces/IProxyStorage.sol
+++ b/contracts/interfaces/IProxyStorage.sol
@@ -11,6 +11,7 @@ interface IProxyStorage {
     function getBallotsStorage() external view returns(address);
     function getKeysManager() external view returns(address);
     function getPoaConsensus() external view returns(address);
+    function getValidatorMetadata() external view returns(address);
     function getVotingToChangeKeys() external view returns(address);
     function getVotingToChangeMinThreshold() external view returns(address);
 }

--- a/contracts/interfaces/IValidatorMetadata.sol
+++ b/contracts/interfaces/IValidatorMetadata.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.24;
+
+
+interface IValidatorMetadata {
+    function clearMetadata(address) external;
+    function moveMetadata(address, address) external;
+}

--- a/test/ballots_storage_test.js
+++ b/test/ballots_storage_test.js
@@ -4,6 +4,7 @@ let BallotsStorage = artifacts.require('./BallotsStorage');
 let BallotsStorageNew = artifacts.require('./upgradeContracts/BallotsStorageNew');
 let VotingToChangeMinThresholdMock = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
 let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
+let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 let EternalStorageProxy = artifacts.require('./EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 require('chai')
@@ -19,7 +20,6 @@ contract('BallotsStorage [all features]', function (accounts) {
   let votingToChangeMinThreshold;
   let votingToChangeProxy;
   let votingToManageEmissionFunds;
-  let validatorMetadataEternalStorage;
   let rewardByBlock;
 
   beforeEach(async () => {
@@ -28,7 +28,6 @@ contract('BallotsStorage [all features]', function (accounts) {
     votingToChangeMinThreshold = accounts[3];
     votingToChangeProxy = accounts[4];
     votingToManageEmissionFunds = accounts[5];
-    validatorMetadataEternalStorage = accounts[7];
     rewardByBlock = accounts[8];
 
     poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
@@ -50,6 +49,9 @@ contract('BallotsStorage [all features]', function (accounts) {
     await keysManager.init(
       "0x0000000000000000000000000000000000000000"
     ).should.be.fulfilled;
+
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorage.address, validatorMetadata.address);
     
     await poaNetworkConsensus.setProxyStorage(proxyStorage.address);
     await proxyStorage.initializeAddresses(
@@ -59,7 +61,7 @@ contract('BallotsStorage [all features]', function (accounts) {
       votingToChangeProxy,
       votingToManageEmissionFunds,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage,
+      validatorMetadataEternalStorage.address,
       rewardByBlock
     );
   })

--- a/test/ballots_storage_upgrade_test.js
+++ b/test/ballots_storage_upgrade_test.js
@@ -4,6 +4,7 @@ let BallotsStorage = artifacts.require('./BallotsStorage');
 let BallotsStorageNew = artifacts.require('./upgradeContracts/BallotsStorageNew');
 let VotingToChangeMinThresholdMock = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
 let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
+let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 let EternalStorageProxy = artifacts.require('./EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 require('chai')
@@ -19,7 +20,6 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
   let votingToChangeMinThreshold;
   let votingToChangeProxy;
   let votingToManageEmissionFunds;
-  let validatorMetadataEternalStorage;
   let rewardByBlock;
 
   beforeEach(async () => {
@@ -28,7 +28,6 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
     votingToChangeMinThreshold = accounts[3];
     votingToChangeProxy = accounts[4];
     votingToManageEmissionFunds = accounts[5];
-    validatorMetadataEternalStorage = accounts[7];
     rewardByBlock = accounts[8];
 
     poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, []);
@@ -50,6 +49,9 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
     await keysManager.init(
       "0x0000000000000000000000000000000000000000"
     ).should.be.fulfilled;
+
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorage.address, validatorMetadata.address);
     
     await poaNetworkConsensus.setProxyStorage(proxyStorage.address);
     await proxyStorage.initializeAddresses(
@@ -59,7 +61,7 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
       votingToChangeProxy,
       votingToManageEmissionFunds,
       ballotsEternalStorage.address,
-      validatorMetadataEternalStorage,
+      validatorMetadataEternalStorage.address,
       rewardByBlock
     );
 

--- a/test/keys_manager_test.js
+++ b/test/keys_manager_test.js
@@ -1,7 +1,9 @@
+let BallotsStorage = artifacts.require('./BallotsStorage');
 let PoaNetworkConsensusMock = artifacts.require('./PoaNetworkConsensusMock');
 let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
 let KeysManagerNew = artifacts.require('./upgradeContracts/KeysManagerNew');
 let ProxyStorageMock = artifacts.require('./mockContracts/ProxyStorageMock');
+let ValidatorMetadata = artifacts.require('./mockContracts/ValidatorMetadataMock');
 let EternalStorageProxy = artifacts.require('./EternalStorageProxyMock');
 
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
@@ -13,6 +15,7 @@ require('chai')
 let keysManager, keysManagerEternalStorage;
 contract('KeysManager [all features]', function (accounts) {
   let poaNetworkConsensusMock, proxyStorageMock;
+  let validatorMetadata;
 
   beforeEach(async () => {
     masterOfCeremony = accounts[0];
@@ -33,6 +36,15 @@ contract('KeysManager [all features]', function (accounts) {
     await keysManager.init(
       "0x0000000000000000000000000000000000000000"
     ).should.be.fulfilled;
+
+    let ballotsStorage = await BallotsStorage.new();
+    let ballotsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, ballotsStorage.address);
+    ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);
+    await ballotsStorage.init([3, 2]).should.be.fulfilled;
+
+    validatorMetadata = await ValidatorMetadata.new();
+    let validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
+    validatorMetadata = ValidatorMetadata.at(validatorMetadataEternalStorage.address);
     
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
 
@@ -42,8 +54,8 @@ contract('KeysManager [all features]', function (accounts) {
       accounts[0],
       accounts[0],
       accounts[0],
-      accounts[0],
-      accounts[0],
+      ballotsStorage.address,
+      validatorMetadata.address,
       accounts[0]
     );
   });
@@ -391,7 +403,40 @@ contract('KeysManager [all features]', function (accounts) {
       await keysManager.removeMiningKey(accounts[1], {from: accounts[3]}).should.be.rejectedWith(ERROR_MSG);
       await addMiningKey(accounts[1], true);
       await addVotingKey(accounts[3], accounts[1], true);
+
+      const validatorData = [
+        "Djamshut", "Roosvelt", "123asd", "Moskva", "ZZ", "234", 23423
+      ];
+      await validatorMetadata.setTime(55555);
+      await validatorMetadata.createMetadata(...validatorData, {from: accounts[3]}).should.be.fulfilled;
+      (await validatorMetadata.validators.call(accounts[1])).should.be.deep.equal([
+        toHex("Djamshut"),
+        toHex("Roosvelt"),
+        pad(web3.toHex("123asd")),
+        "Moskva",
+        toHex("ZZ"),
+        pad(web3.toHex("234")),
+        new web3.BigNumber(23423),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(0),
+        new web3.BigNumber(2)
+      ]);
+
       const {logs} = await keysManager.removeMiningKey(accounts[1]).should.be.fulfilled;
+
+      (await validatorMetadata.validators.call(accounts[1])).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
+      
       const validator = await keysManager.validatorKeys.call(accounts[1]);
       validator.should.be.deep.equal(
         [ '0x0000000000000000000000000000000000000000',
@@ -399,7 +444,7 @@ contract('KeysManager [all features]', function (accounts) {
         false,
         false,
         false ]
-      )
+      );
       logs[0].event.should.be.equal('MiningKeyChanged');
       logs[0].args.key.should.be.equal(accounts[1]);
       logs[0].args.action.should.be.equal('removed');
@@ -585,24 +630,60 @@ contract('KeysManager [all features]', function (accounts) {
     it('should swap mining key', async () => {
       await keysManager.swapMiningKey(accounts[1], accounts[2], {from: accounts[4]}).should.be.rejectedWith(ERROR_MSG);
       await addMiningKey(accounts[1], true);
+      await addVotingKey(accounts[5], accounts[1], true);
+
+      const validatorData = [
+        "Djamshut", "Roosvelt", "123asd", "Moskva", "ZZ", "234", 23423
+      ];
+      await validatorMetadata.setTime(55555);
+      await validatorMetadata.createMetadata(...validatorData, {from: accounts[5]}).should.be.fulfilled;
+
       await swapMiningKey(accounts[2], accounts[1], true);
       await swapMiningKey(accounts[4], accounts[3], false);
+
       const validator = await keysManager.validatorKeys.call(accounts[1]);
-      validator.should.be.deep.equal(
-        [ '0x0000000000000000000000000000000000000000',
+      validator.should.be.deep.equal([
+        '0x0000000000000000000000000000000000000000',
         '0x0000000000000000000000000000000000000000',
         false,
         false,
-        false ]
-      )
+        false
+      ]);
+
       const validatorNew = await keysManager.validatorKeys.call(accounts[2]);
-      validatorNew.should.be.deep.equal(
-        [ '0x0000000000000000000000000000000000000000',
+      validatorNew.should.be.deep.equal([
+        accounts[5],
         '0x0000000000000000000000000000000000000000',
         true,
-        false,
-        false]
-      )
+        true,
+        false
+      ]);
+
+      (await validatorMetadata.validators.call(accounts[2])).should.be.deep.equal([
+        toHex("Djamshut"),
+        toHex("Roosvelt"),
+        pad(web3.toHex("123asd")),
+        "Moskva",
+        toHex("ZZ"),
+        pad(web3.toHex("234")),
+        new web3.BigNumber(23423),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(0),
+        new web3.BigNumber(2)
+      ]);
+
+      (await validatorMetadata.validators.call(accounts[1])).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
     });
     it('should swap MoC', async () => {
       (await keysManager.masterOfCeremony.call()).should.be.equal(masterOfCeremony);
@@ -911,6 +992,19 @@ contract('KeysManager [all features]', function (accounts) {
     });
   });
 });
+
+function toHex(someString) {
+  var hex = '0x' + new Buffer(someString).toString('hex');
+  hex = pad(hex);
+  return hex;
+}
+
+function pad(hex) {
+  while(hex.length !== 66){
+    hex = hex + '0';
+  }
+  return hex;
+}
 
 async function addMiningKey(_key, _shouldBeSuccessful, options) {
   const result = await keysManager.addMiningKey(_key, options);

--- a/test/metadata_upgrade_test.js
+++ b/test/metadata_upgrade_test.js
@@ -64,6 +64,7 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
 
     metadata = await ValidatorMetadata.new();
     metadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, metadata.address);
+    metadata = await ValidatorMetadata.at(metadataEternalStorage.address);
     
     await proxyStorageMock.initializeAddresses(
       keysManager.address,
@@ -89,8 +90,9 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
     await addVotingKey(votingKey2, miningKey2);
     await addMiningKey(miningKey3);
     await addVotingKey(votingKey3, miningKey3);
+
     await metadata.setTime(55555);
-  })
+  });
 
   describe('#createMetadata', async () => {
     it('happy path', async () => {
@@ -132,7 +134,198 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       await metadata.createMetadata(...fakeData, {from: votingKey}).should.be.fulfilled;
       await metadata.createMetadata(...fakeData, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
     });
-  })
+  });
+
+  describe('#clearMetadata', async () => {
+    it('happy path', async () => {
+      let result = await metadata.createMetadata(...fakeData, {from: votingKey}).should.be.fulfilled;
+      (await metadata.validators.call(miningKey)).should.be.deep.equal([
+        toHex("Djamshut"),
+        toHex("Roosvelt"),
+        pad(web3.toHex("123asd")),
+        "Moskva",
+        toHex("ZZ"),
+        pad(web3.toHex("234")),
+        new web3.BigNumber(23423),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(0),
+        new web3.BigNumber(2)
+      ]);
+      result.logs[0].event.should.be.equal('MetadataCreated');
+      result.logs[0].args.miningKey.should.be.equal(miningKey);
+
+      await metadata.setTime(4444);
+      result = await metadata.changeRequest(...newMetadata, {from: votingKey}).should.be.fulfilled;
+      (await metadata.pendingChanges.call(miningKey)).should.be.deep.equal([
+        toHex("Feodosiy"),
+        toHex("Kennedy"),
+        pad(web3.toHex("123123")),
+        "Petrovka 38",
+        toHex("ZA"),
+        pad(web3.toHex("1337")),
+        new web3.BigNumber(71),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(4444),
+        new web3.BigNumber(2)
+      ]);
+      result.logs[0].event.should.be.equal("ChangeRequestInitiated");
+      result.logs[0].args.miningKey.should.be.equal(miningKey);
+
+      await proxyStorageMock.setKeysManagerMock(accounts[0]);
+      result = await metadata.clearMetadata(miningKey);
+      result.logs[0].event.should.be.equal('MetadataCleared');
+      result.logs[0].args.miningKey.should.be.equal(miningKey);
+      await proxyStorageMock.setKeysManagerMock(keysManager.address);
+
+      (await metadata.validators.call(miningKey)).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
+
+      (await metadata.pendingChanges.call(miningKey)).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
+    });
+  });
+
+  describe('#moveMetadata', async () => {
+    it('happy path', async () => {
+      let result = await metadata.createMetadata(...fakeData, {from: votingKey}).should.be.fulfilled;
+      (await metadata.validators.call(miningKey)).should.be.deep.equal([
+        toHex("Djamshut"),
+        toHex("Roosvelt"),
+        pad(web3.toHex("123asd")),
+        "Moskva",
+        toHex("ZZ"),
+        pad(web3.toHex("234")),
+        new web3.BigNumber(23423),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(0),
+        new web3.BigNumber(2)
+      ]);
+      result.logs[0].event.should.be.equal('MetadataCreated');
+      result.logs[0].args.miningKey.should.be.equal(miningKey);
+
+      await metadata.setTime(4444);
+      result = await metadata.changeRequest(...newMetadata, {from: votingKey}).should.be.fulfilled;
+      (await metadata.pendingChanges.call(miningKey)).should.be.deep.equal([
+        toHex("Feodosiy"),
+        toHex("Kennedy"),
+        pad(web3.toHex("123123")),
+        "Petrovka 38",
+        toHex("ZA"),
+        pad(web3.toHex("1337")),
+        new web3.BigNumber(71),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(4444),
+        new web3.BigNumber(2)
+      ]);
+      result.logs[0].event.should.be.equal("ChangeRequestInitiated");
+      result.logs[0].args.miningKey.should.be.equal(miningKey);
+
+      (await metadata.validators.call(miningKey2)).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
+
+      (await metadata.pendingChanges.call(miningKey2)).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
+
+      await proxyStorageMock.setKeysManagerMock(accounts[0]);
+      result = await metadata.moveMetadata(miningKey, miningKey2);
+      result.logs[0].event.should.be.equal('MetadataMoved');
+      result.logs[0].args.oldMiningKey.should.be.equal(miningKey);
+      result.logs[0].args.newMiningKey.should.be.equal(miningKey2);
+      await proxyStorageMock.setKeysManagerMock(keysManager.address);
+
+      (await metadata.validators.call(miningKey)).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
+
+      (await metadata.pendingChanges.call(miningKey)).should.be.deep.equal([
+        toHex(""),
+        toHex(""),
+        toHex(""),
+        "",
+        toHex(""),
+        toHex(""),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0),
+        new web3.BigNumber(0)
+      ]);
+
+      (await metadata.validators.call(miningKey2)).should.be.deep.equal([
+        toHex("Djamshut"),
+        toHex("Roosvelt"),
+        pad(web3.toHex("123asd")),
+        "Moskva",
+        toHex("ZZ"),
+        pad(web3.toHex("234")),
+        new web3.BigNumber(23423),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(0),
+        new web3.BigNumber(2)
+      ]);
+
+      (await metadata.pendingChanges.call(miningKey2)).should.be.deep.equal([
+        toHex("Feodosiy"),
+        toHex("Kennedy"),
+        pad(web3.toHex("123123")),
+        "Petrovka 38",
+        toHex("ZA"),
+        pad(web3.toHex("1337")),
+        new web3.BigNumber(71),
+        new web3.BigNumber(55555),
+        new web3.BigNumber(4444),
+        new web3.BigNumber(2)
+      ]);
+    });
+  });
 
   describe('#initMetadata', async () => {
     it('happy path', async () => {

--- a/test/reward_by_block_test.js
+++ b/test/reward_by_block_test.js
@@ -4,6 +4,7 @@ const EternalStorageProxy = artifacts.require('./mockContracts/EternalStoragePro
 const KeysManager = artifacts.require('./mockContracts/KeysManagerMock');
 const PoaNetworkConsensus = artifacts.require('./mockContracts/PoaNetworkConsensusMock');
 const ProxyStorage = artifacts.require('./mockContracts/ProxyStorageMock');
+const ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 const {getRandomInt} = require('./utils/helpers');
 
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
@@ -57,6 +58,9 @@ contract('RewardByBlock [all features]', function (accounts) {
       "0x0000000000000000000000000000000000000000"
     ).should.be.fulfilled;
 
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorage.address, validatorMetadata.address);
+
     await proxyStorage.initializeAddresses(
       keysManagerEternalStorage.address,
       votingToChangeKeys,
@@ -64,7 +68,7 @@ contract('RewardByBlock [all features]', function (accounts) {
       accounts[9],
       accounts[9],
       accounts[9],
-      accounts[9],
+      validatorMetadataEternalStorage.address,
       accounts[9]
     );
 

--- a/test/reward_by_time_test.js
+++ b/test/reward_by_time_test.js
@@ -4,6 +4,7 @@ const EternalStorageProxy = artifacts.require('./mockContracts/EternalStoragePro
 const KeysManager = artifacts.require('./mockContracts/KeysManagerMock');
 const PoaNetworkConsensus = artifacts.require('./mockContracts/PoaNetworkConsensusMock');
 const ProxyStorage = artifacts.require('./mockContracts/ProxyStorageMock');
+const ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 const {getRandomInt} = require('./utils/helpers');
 
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
@@ -57,6 +58,9 @@ contract('RewardByTime [all features]', function (accounts) {
       "0x0000000000000000000000000000000000000000"
     ).should.be.fulfilled;
 
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorage.address, validatorMetadata.address);
+
     await proxyStorage.initializeAddresses(
       keysManagerEternalStorage.address,
       votingToChangeKeys,
@@ -64,7 +68,7 @@ contract('RewardByTime [all features]', function (accounts) {
       accounts[9],
       accounts[9],
       accounts[9],
-      accounts[9],
+      validatorMetadataEternalStorage.address,
       accounts[9]
     );
 

--- a/test/reward_by_time_upgrade_test.js
+++ b/test/reward_by_time_upgrade_test.js
@@ -4,6 +4,7 @@ const EternalStorageProxy = artifacts.require('./mockContracts/EternalStoragePro
 const KeysManager = artifacts.require('./mockContracts/KeysManagerMock');
 const PoaNetworkConsensus = artifacts.require('./mockContracts/PoaNetworkConsensusMock');
 const ProxyStorage = artifacts.require('./mockContracts/ProxyStorageMock');
+const ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 const {getRandomInt} = require('./utils/helpers');
 
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
@@ -57,6 +58,9 @@ contract('RewardByTime upgraded [all features]', function (accounts) {
       "0x0000000000000000000000000000000000000000"
     ).should.be.fulfilled;
 
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorage.address, validatorMetadata.address);
+
     await proxyStorage.initializeAddresses(
       keysManagerEternalStorage.address,
       votingToChangeKeys,
@@ -64,7 +68,7 @@ contract('RewardByTime upgraded [all features]', function (accounts) {
       accounts[9],
       accounts[9],
       accounts[9],
-      accounts[9],
+      validatorMetadataEternalStorage.address,
       accounts[9]
     );
 

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -4,6 +4,7 @@ let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
 let VotingToChangeKeysMock = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 let VotingToChangeKeysNew = artifacts.require('./upgradeContracts/VotingToChangeKeysNew');
 let BallotsStorage = artifacts.require('./BallotsStorage');
+let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const moment = require('moment');
@@ -46,6 +47,9 @@ contract('Voting to change keys [all features]', function (accounts) {
     let ballotsStorage = await BallotsStorage.new();
     const ballotsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, ballotsStorage.address);
 
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
+
     voting = await VotingToChangeKeysMock.new();
     votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
 
@@ -56,7 +60,7 @@ contract('Voting to change keys [all features]', function (accounts) {
       accounts[0],
       accounts[0],
       ballotsEternalStorage.address,
-      accounts[0],
+      validatorMetadataEternalStorage.address,
       accounts[0]
     );
 

--- a/test/voting_to_change_keys_upgrade_test.js
+++ b/test/voting_to_change_keys_upgrade_test.js
@@ -4,6 +4,7 @@ let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
 let VotingToChangeKeysMock = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 let VotingToChangeKeysNew = artifacts.require('./upgradeContracts/VotingToChangeKeysNew');
 let BallotsStorage = artifacts.require('./BallotsStorage');
+let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const moment = require('moment');
@@ -46,7 +47,10 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
     let ballotsStorage = await BallotsStorage.new();
     const ballotsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, ballotsStorage.address);
     ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);
-    
+
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
+
     voting = await VotingToChangeKeysMock.new();
     votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
     voting = await VotingToChangeKeysMock.at(votingEternalStorage.address);
@@ -58,7 +62,7 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       accounts[0],
       accounts[0],
       ballotsEternalStorage.address,
-      accounts[0],
+      validatorMetadataEternalStorage.address,
       accounts[0]
     );
 

--- a/test/voting_to_change_min_threshold_test.js
+++ b/test/voting_to_change_min_threshold_test.js
@@ -5,6 +5,7 @@ let Voting = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock')
 let VotingNew = artifacts.require('./upgradeContracts/VotingToChangeMinThresholdNew');
 let VotingForKeys = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 let BallotsStorage = artifacts.require('./mockContracts/BallotsStorageMock');
+let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const moment = require('moment');
@@ -47,6 +48,9 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
     
     ballotsStorage = await BallotsStorage.new();
     const ballotsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, ballotsStorage.address);
+
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
     
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     
@@ -63,7 +67,7 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
       accounts[0],
       accounts[0],
       ballotsEternalStorage.address,
-      accounts[0],
+      validatorMetadataEternalStorage.address,
       accounts[0]
     );
     

--- a/test/voting_to_change_min_threshold_upgrade_test.js
+++ b/test/voting_to_change_min_threshold_upgrade_test.js
@@ -5,6 +5,7 @@ let Voting = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock')
 let VotingNew = artifacts.require('./upgradeContracts/VotingToChangeMinThresholdNew');
 let VotingForKeys = artifacts.require('./mockContracts/VotingToChangeKeysMock');
 let BallotsStorage = artifacts.require('./mockContracts/BallotsStorageMock');
+let ValidatorMetadata = artifacts.require('./ValidatorMetadata');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const moment = require('moment');
@@ -47,6 +48,9 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     
     ballotsStorage = await BallotsStorage.new();
     const ballotsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, ballotsStorage.address);
+
+    const validatorMetadata = await ValidatorMetadata.new();
+    const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
     
     await poaNetworkConsensusMock.setProxyStorage(proxyStorageMock.address);
     
@@ -70,7 +74,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       accounts[0],
       accounts[0],
       ballotsEternalStorage.address,
-      accounts[0],
+      validatorMetadataEternalStorage.address,
       accounts[0]
     );
     


### PR DESCRIPTION
**(Mandatory) Description**

`ValidatorMetadata` contract has been complemented by `moveMetadata` and `clearMetadata` external functions that can only be called by `KeysManager` contract.

`moveMetadata` function is called by `KeysManager.swapMiningKey` function to keep metadata of validator when his mining key is swapped.

`clearMetadata` function is called by `KeysManager.removeMiningKey` function to clear metadata of validator when his mining key is removed.

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Fix)