### PR TITLE
(Fix) Replace abi.encodePacked with abi.encode

### DIFF
--- a/contracts/BallotsStorage.sol
+++ b/contracts/BallotsStorage.sol
@@ -80,9 +80,9 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
     ) public onlyOwner {
         require(!initDisabled());
         require(_thresholds.length == uint256(ThresholdTypes.MetadataChange));
-        require(_thresholds.length <= 255);
+        require(_thresholds.length < 255);
         for (uint8 thresholdType = uint8(ThresholdTypes.Keys); thresholdType <= _thresholds.length; thresholdType++) {
-            uint256 thresholdValue = _thresholds[thresholdType - 1];
+            uint256 thresholdValue = _thresholds[thresholdType - uint8(ThresholdTypes.Keys)];
             require(thresholdValue > 0);
             _setThreshold(thresholdValue, thresholdType);
         }
@@ -111,7 +111,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         onlyVotingToChangeThreshold
         returns(bool)
     {
-        if (_thresholdType == 0) return false;
+        if (_thresholdType == uint8(ThresholdTypes.Invalid)) return false;
         if (_thresholdType > uint8(ThresholdTypes.MetadataChange)) return false;
         if (_newValue == 0) return false;
         if (_newValue == getBallotThreshold(_thresholdType)) return false;

--- a/contracts/BallotsStorage.sol
+++ b/contracts/BallotsStorage.sol
@@ -121,7 +121,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
     }
 
     function getBallotThreshold(uint8 _ballotType) public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(BALLOT_THRESHOLDS, _ballotType))];
+        return uintStorage[keccak256(abi.encode(BALLOT_THRESHOLDS, _ballotType))];
     }
 
     function getVotingToChangeThreshold() public view returns(address) {
@@ -233,7 +233,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
 
     function _setThreshold(uint256 _newValue, uint8 _thresholdType) internal {
         uintStorage[
-            keccak256(abi.encodePacked(BALLOT_THRESHOLDS, _thresholdType))
+            keccak256(abi.encode(BALLOT_THRESHOLDS, _thresholdType))
         ] = _newValue;
     }
 }

--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -136,31 +136,31 @@ contract KeysManager is EternalStorage, IKeysManager {
 
     function getInitialKeyStatus(address _initialKey) public view returns(uint8) {
         return uint8(uintStorage[
-            keccak256(abi.encodePacked(INITIAL_KEY_STATUS, _initialKey))
+            keccak256(abi.encode(INITIAL_KEY_STATUS, _initialKey))
         ]);
     }
 
     function miningKeyByPayout(address _payoutKey) public view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(MINING_KEY_BY_PAYOUT, _payoutKey))
+            keccak256(abi.encode(MINING_KEY_BY_PAYOUT, _payoutKey))
         ];
     }
 
     function miningKeyByVoting(address _votingKey) public view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(MINING_KEY_BY_VOTING, _votingKey))
+            keccak256(abi.encode(MINING_KEY_BY_VOTING, _votingKey))
         ];
     }
 
     function miningKeyHistory(address _miningKey) public view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(MINING_KEY_HISTORY, _miningKey))
+            keccak256(abi.encode(MINING_KEY_HISTORY, _miningKey))
         ];
     }
 
     function successfulValidatorClone(address _miningKey) public view returns(bool) {
         return boolStorage[
-            keccak256(abi.encodePacked(SUCCESSFUL_VALIDATOR_CLONE, _miningKey))
+            keccak256(abi.encode(SUCCESSFUL_VALIDATOR_CLONE, _miningKey))
         ];
     }
 
@@ -310,7 +310,7 @@ contract KeysManager is EternalStorage, IKeysManager {
 
     function isMiningActive(address _key) public view returns(bool) {
         return boolStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _key, IS_MINING_ACTIVE))
+            keccak256(abi.encode(VALIDATOR_KEYS, _key, IS_MINING_ACTIVE))
         ];
     }
 
@@ -321,25 +321,25 @@ contract KeysManager is EternalStorage, IKeysManager {
 
     function isVotingActiveByMiningKey(address _miningKey) public view returns(bool) {
         return boolStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, IS_VOTING_ACTIVE))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, IS_VOTING_ACTIVE))
         ];
     }
 
     function isPayoutActive(address _miningKey) public view returns(bool) {
         return boolStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, IS_PAYOUT_ACTIVE))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, IS_PAYOUT_ACTIVE))
         ];
     }
 
     function getVotingByMining(address _miningKey) public view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, VOTING_KEY))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, VOTING_KEY))
         ];
     }
 
     function getPayoutByMining(address _miningKey) public view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, PAYOUT_KEY))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, PAYOUT_KEY))
         ];
     }
 
@@ -536,63 +536,63 @@ contract KeysManager is EternalStorage, IKeysManager {
 
     function _setInitialKeyStatus(address _initialKey, uint8 _status) private {
         uintStorage[
-            keccak256(abi.encodePacked(INITIAL_KEY_STATUS, _initialKey))
+            keccak256(abi.encode(INITIAL_KEY_STATUS, _initialKey))
         ] = _status;
     }
 
     function _setVotingKey(address _key, address _miningKey) private {
         addressStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, VOTING_KEY))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, VOTING_KEY))
         ] = _key;
     }
 
     function _setPayoutKey(address _key, address _miningKey) private {
         addressStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, PAYOUT_KEY))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, PAYOUT_KEY))
         ] = _key;
     }
 
     function _setIsMiningActive(bool _active, address _miningKey) private {
         boolStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, IS_MINING_ACTIVE))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, IS_MINING_ACTIVE))
         ] = _active;
     }
 
     function _setIsVotingActive(bool _active, address _miningKey) private {
         boolStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, IS_VOTING_ACTIVE))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, IS_VOTING_ACTIVE))
         ] = _active;
     }
 
     function _setIsPayoutActive(bool _active, address _miningKey) private {
         boolStorage[
-            keccak256(abi.encodePacked(VALIDATOR_KEYS, _miningKey, IS_PAYOUT_ACTIVE))
+            keccak256(abi.encode(VALIDATOR_KEYS, _miningKey, IS_PAYOUT_ACTIVE))
         ] = _active;
     }
 
     function _setMiningKeyByPayout(address _payoutKey, address _miningKey) private {
         if (_payoutKey == address(0)) return;
         addressStorage[
-            keccak256(abi.encodePacked(MINING_KEY_BY_PAYOUT, _payoutKey))
+            keccak256(abi.encode(MINING_KEY_BY_PAYOUT, _payoutKey))
         ] = _miningKey;
     }
 
     function _setMiningKeyByVoting(address _votingKey, address _miningKey) private {
         if (_votingKey == address(0)) return;
         addressStorage[
-            keccak256(abi.encodePacked(MINING_KEY_BY_VOTING, _votingKey))
+            keccak256(abi.encode(MINING_KEY_BY_VOTING, _votingKey))
         ] = _miningKey;
     }
 
     function _setMiningKeyHistory(address _key, address _oldMiningKey) private {
         addressStorage[
-            keccak256(abi.encodePacked(MINING_KEY_HISTORY, _key))
+            keccak256(abi.encode(MINING_KEY_HISTORY, _key))
         ] = _oldMiningKey;
     }
 
     function _setSuccessfulValidatorClone(bool _success, address _miningKey) private {
         boolStorage[
-            keccak256(abi.encodePacked(SUCCESSFUL_VALIDATOR_CLONE, _miningKey))
+            keccak256(abi.encode(SUCCESSFUL_VALIDATOR_CLONE, _miningKey))
         ] = _success;
     }
 

--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -93,7 +93,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
 
     function extraReceiversAmounts(address _receiver) public view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(EXTRA_RECEIVERS_AMOUNTS, _receiver))
+            keccak256(abi.encode(EXTRA_RECEIVERS_AMOUNTS, _receiver))
         ];
     }
 
@@ -138,7 +138,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
 
     function _setExtraReceiverAmount(address _receiver, uint256 _amount) private {
         uintStorage[
-            keccak256(abi.encodePacked(EXTRA_RECEIVERS_AMOUNTS, _receiver))
+            keccak256(abi.encode(EXTRA_RECEIVERS_AMOUNTS, _receiver))
         ] = _amount;
     }
 }

--- a/contracts/ValidatorMetadata.sol
+++ b/contracts/ValidatorMetadata.sol
@@ -233,7 +233,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
             getMinThreshold()
         );
         _setMinThreshold(true, miningKey, _getMinThreshold(false, miningKey));
-        delete addressArrayStorage[keccak256(abi.encodePacked(
+        delete addressArrayStorage[keccak256(abi.encode(
             CONFIRMATIONS, miningKey, VOTERS
         ))];
         emit ChangeRequestInitiated(miningKey);
@@ -322,7 +322,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(bytes32)
     {
-        return bytes32Storage[keccak256(abi.encodePacked(
+        return bytes32Storage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, FIRST_NAME
         ))];
     }
@@ -332,7 +332,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(bytes32)
     {
-        return bytes32Storage[keccak256(abi.encodePacked(
+        return bytes32Storage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, LAST_NAME
         ))];
     }
@@ -342,7 +342,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(bytes32)
     {
-        return bytes32Storage[keccak256(abi.encodePacked(
+        return bytes32Storage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, LICENSE_ID
         ))];
     }
@@ -352,7 +352,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(string)
     {
-        return stringStorage[keccak256(abi.encodePacked(
+        return stringStorage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, FULL_ADDRESS
         ))];
     }
@@ -362,7 +362,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(bytes32)
     {
-        return bytes32Storage[keccak256(abi.encodePacked(
+        return bytes32Storage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, STATE
         ))];
     }
@@ -372,7 +372,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(bytes32)
     {
-        return bytes32Storage[keccak256(abi.encodePacked(
+        return bytes32Storage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, ZIP_CODE
         ))];
     }
@@ -382,7 +382,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(uint256)
     {
-        return uintStorage[keccak256(abi.encodePacked(
+        return uintStorage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, EXPIRATION_DATE
         ))];
     }
@@ -392,7 +392,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(uint256)
     {
-        return uintStorage[keccak256(abi.encodePacked(
+        return uintStorage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, CREATED_DATE
         ))];
     }
@@ -402,7 +402,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(uint256)
     {
-        return uintStorage[keccak256(abi.encodePacked(
+        return uintStorage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, UPDATED_DATE
         ))];
     }
@@ -412,7 +412,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(uint256)
     {
-        return uintStorage[keccak256(abi.encodePacked(
+        return uintStorage[keccak256(abi.encode(
             _storeName(_pending), _miningKey, MIN_THRESHOLD
         ))];
     }
@@ -422,7 +422,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         view
         returns(address[] voters)
     {
-        voters = addressArrayStorage[keccak256(abi.encodePacked(
+        voters = addressArrayStorage[keccak256(abi.encode(
             CONFIRMATIONS, _miningKey, VOTERS
         ))];
     }
@@ -458,16 +458,16 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
 
     function _deleteMetadata(bool _pending, address _miningKey) private {
         string memory _store = _storeName(_pending);
-        delete bytes32Storage[keccak256(abi.encodePacked(_store, _miningKey, FIRST_NAME))];
-        delete bytes32Storage[keccak256(abi.encodePacked(_store, _miningKey, LAST_NAME))];
-        delete bytes32Storage[keccak256(abi.encodePacked(_store, _miningKey, LICENSE_ID))];
-        delete bytes32Storage[keccak256(abi.encodePacked(_store, _miningKey, STATE))];
-        delete stringStorage[keccak256(abi.encodePacked(_store, _miningKey, FULL_ADDRESS))];
-        delete bytes32Storage[keccak256(abi.encodePacked(_store, _miningKey, ZIP_CODE))];
-        delete uintStorage[keccak256(abi.encodePacked(_store, _miningKey, EXPIRATION_DATE))];
-        delete uintStorage[keccak256(abi.encodePacked(_store, _miningKey, CREATED_DATE))];
-        delete uintStorage[keccak256(abi.encodePacked(_store, _miningKey, UPDATED_DATE))];
-        delete uintStorage[keccak256(abi.encodePacked(_store, _miningKey, MIN_THRESHOLD))];
+        delete bytes32Storage[keccak256(abi.encode(_store, _miningKey, FIRST_NAME))];
+        delete bytes32Storage[keccak256(abi.encode(_store, _miningKey, LAST_NAME))];
+        delete bytes32Storage[keccak256(abi.encode(_store, _miningKey, LICENSE_ID))];
+        delete bytes32Storage[keccak256(abi.encode(_store, _miningKey, STATE))];
+        delete stringStorage[keccak256(abi.encode(_store, _miningKey, FULL_ADDRESS))];
+        delete bytes32Storage[keccak256(abi.encode(_store, _miningKey, ZIP_CODE))];
+        delete uintStorage[keccak256(abi.encode(_store, _miningKey, EXPIRATION_DATE))];
+        delete uintStorage[keccak256(abi.encode(_store, _miningKey, CREATED_DATE))];
+        delete uintStorage[keccak256(abi.encode(_store, _miningKey, UPDATED_DATE))];
+        delete uintStorage[keccak256(abi.encode(_store, _miningKey, MIN_THRESHOLD))];
     }
 
     function _moveMetadata(bool _pending, address _oldMiningKey, address _newMiningKey) private {
@@ -489,7 +489,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     }
 
     function _setFirstName(bool _pending, address _miningKey, bytes32 _firstName) private {
-        bytes32Storage[keccak256(abi.encodePacked(
+        bytes32Storage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             FIRST_NAME
@@ -497,7 +497,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     }
 
     function _setLastName(bool _pending, address _miningKey, bytes32 _lastName) private {
-        bytes32Storage[keccak256(abi.encodePacked(
+        bytes32Storage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             LAST_NAME
@@ -505,7 +505,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     }
 
     function _setLicenseId(bool _pending, address _miningKey, bytes32 _licenseId) private {
-        bytes32Storage[keccak256(abi.encodePacked(
+        bytes32Storage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             LICENSE_ID
@@ -513,7 +513,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     }
 
     function _setState(bool _pending, address _miningKey, bytes32 _state) private {
-        bytes32Storage[keccak256(abi.encodePacked(
+        bytes32Storage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             STATE
@@ -525,7 +525,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         address _miningKey,
         string _fullAddress
     ) private {
-        stringStorage[keccak256(abi.encodePacked(
+        stringStorage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             FULL_ADDRESS
@@ -533,7 +533,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     }
 
     function _setZipcode(bool _pending, address _miningKey, bytes32 _zipcode) private {
-        bytes32Storage[keccak256(abi.encodePacked(
+        bytes32Storage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             ZIP_CODE
@@ -545,7 +545,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         address _miningKey,
         uint256 _expirationDate
     ) private {
-        uintStorage[keccak256(abi.encodePacked(
+        uintStorage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             EXPIRATION_DATE
@@ -557,7 +557,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         address _miningKey,
         uint256 _createdDate
     ) private {
-        uintStorage[keccak256(abi.encodePacked(
+        uintStorage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             CREATED_DATE
@@ -569,7 +569,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         address _miningKey,
         uint256 _updatedDate
     ) private {
-        uintStorage[keccak256(abi.encodePacked(
+        uintStorage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             UPDATED_DATE
@@ -607,7 +607,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         address _miningKey,
         uint256 _minThreshold
     ) private {
-        uintStorage[keccak256(abi.encodePacked(
+        uintStorage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,
             MIN_THRESHOLD
@@ -615,7 +615,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     }
 
     function _confirmationsVoterAdd(address _miningKey, address _voterMiningKey) private {
-        addressArrayStorage[keccak256(abi.encodePacked(
+        addressArrayStorage[keccak256(abi.encode(
             CONFIRMATIONS, _miningKey, VOTERS
         ))].push(_voterMiningKey);
     }

--- a/contracts/VotingToChangeKeys.sol
+++ b/contracts/VotingToChangeKeys.sol
@@ -221,73 +221,73 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange, EnumKeyTypes
 
     function _getAffectedKey(uint256 _id) internal view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, AFFECTED_KEY))
+            keccak256(abi.encode(VOTING_STATE, _id, AFFECTED_KEY))
         ];
     }
 
     function _getAffectedKeyType(uint256 _id) internal view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, AFFECTED_KEY_TYPE))
+            keccak256(abi.encode(VOTING_STATE, _id, AFFECTED_KEY_TYPE))
         ];
     }
 
     function _getBallotType(uint256 _id) internal view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, BALLOT_TYPE))
+            keccak256(abi.encode(VOTING_STATE, _id, BALLOT_TYPE))
         ];
     }
 
     function _getMiningKey(uint256 _id) internal view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, MINING_KEY))
+            keccak256(abi.encode(VOTING_STATE, _id, MINING_KEY))
         ];
     }
 
     function _getNewPayoutKey(uint256 _id) internal view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, NEW_PAYOUT_KEY))
+            keccak256(abi.encode(VOTING_STATE, _id, NEW_PAYOUT_KEY))
         ];
     }
 
     function _getNewVotingKey(uint256 _id) internal view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, NEW_VOTING_KEY))
+            keccak256(abi.encode(VOTING_STATE, _id, NEW_VOTING_KEY))
         ];
     }
 
     function _setAffectedKey(uint256 _ballotId, address _value) internal {
         addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, AFFECTED_KEY))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, AFFECTED_KEY))
         ] = _value;
     }
 
     function _setAffectedKeyType(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, AFFECTED_KEY_TYPE))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, AFFECTED_KEY_TYPE))
         ] = _value;
     }
 
     function _setBallotType(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, BALLOT_TYPE))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, BALLOT_TYPE))
         ] = _value;
     }
 
     function _setMiningKey(uint256 _ballotId, address _value) internal {
         addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, MINING_KEY))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, MINING_KEY))
         ] = _value;
     }
 
     function _setNewPayoutKey(uint256 _ballotId, address _value) internal {
         addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, NEW_PAYOUT_KEY))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, NEW_PAYOUT_KEY))
         ] = _value;
     }
 
     function _setNewVotingKey(uint256 _ballotId, address _value) internal {
         addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, NEW_VOTING_KEY))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, NEW_VOTING_KEY))
         ] = _value;
     }
 

--- a/contracts/VotingToChangeMinThreshold.sol
+++ b/contracts/VotingToChangeMinThreshold.sol
@@ -94,12 +94,12 @@ contract VotingToChangeMinThreshold is IVotingToChangeMinThreshold, VotingToChan
     }
 
     function _getProposedValue(uint256 _id) internal view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, PROPOSED_VALUE))];
+        return uintStorage[keccak256(abi.encode(VOTING_STATE, _id, PROPOSED_VALUE))];
     }
 
     function _setProposedValue(uint256 _ballotId, uint256 _value) private {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, PROPOSED_VALUE))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, PROPOSED_VALUE))
         ] = _value;
     }
 

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -87,7 +87,7 @@ contract VotingToChangeProxyAddress is IVotingToChangeProxyAddress, VotingToChan
 
     function _getContractType(uint256 _id) internal view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, CONTRACT_TYPE))
+            keccak256(abi.encode(VOTING_STATE, _id, CONTRACT_TYPE))
         ];
     }
 
@@ -98,19 +98,19 @@ contract VotingToChangeProxyAddress is IVotingToChangeProxyAddress, VotingToChan
 
     function _getProposedValue(uint256 _id) internal view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, PROPOSED_VALUE))
+            keccak256(abi.encode(VOTING_STATE, _id, PROPOSED_VALUE))
         ];
     }
 
     function _setContractType(uint256 _ballotId, uint256 _value) private {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, CONTRACT_TYPE))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, CONTRACT_TYPE))
         ] = _value;
     }
 
     function _setProposedValue(uint256 _ballotId, address _value) private {
         addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, PROPOSED_VALUE))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, PROPOSED_VALUE))
         ] = _value;
     }
 

--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -89,7 +89,7 @@ contract VotingToManageEmissionFunds is VotingTo {
     }
 
     function getAmount(uint256 _id) public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, AMOUNT))];
+        return uintStorage[keccak256(abi.encode(VOTING_STATE, _id, AMOUNT))];
     }
 
     function getBallotInfo(uint256 _id, address _votingKey) public view returns(
@@ -119,19 +119,19 @@ contract VotingToManageEmissionFunds is VotingTo {
     }
 
     function getBurnVotes(uint256 _id) public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, BURN_VOTES))];
+        return uintStorage[keccak256(abi.encode(VOTING_STATE, _id, BURN_VOTES))];
     }
 
     function getFreezeVotes(uint256 _id) public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, FREEZE_VOTES))];
+        return uintStorage[keccak256(abi.encode(VOTING_STATE, _id, FREEZE_VOTES))];
     }
 
     function getReceiver(uint256 _id) public view returns(address) {
-        return addressStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, RECEIVER))];
+        return addressStorage[keccak256(abi.encode(VOTING_STATE, _id, RECEIVER))];
     }
 
     function getSendVotes(uint256 _id) public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, SEND_VOTES))];
+        return uintStorage[keccak256(abi.encode(VOTING_STATE, _id, SEND_VOTES))];
     }
 
     function getTotalVoters(uint256 _id) public view returns(uint256) {
@@ -273,13 +273,13 @@ contract VotingToManageEmissionFunds is VotingTo {
 
     function _setAmount(uint256 _ballotId, uint256 _amount) private {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, AMOUNT))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, AMOUNT))
         ] = _amount;
     }
 
     function _setBurnVotes(uint256 _ballotId, uint256 _value) private {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, BURN_VOTES))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, BURN_VOTES))
         ] = _value;
     }
 
@@ -289,7 +289,7 @@ contract VotingToManageEmissionFunds is VotingTo {
 
     function _setFreezeVotes(uint256 _ballotId, uint256 _value) private {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, FREEZE_VOTES))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, FREEZE_VOTES))
         ] = _value;
     }
 
@@ -299,13 +299,13 @@ contract VotingToManageEmissionFunds is VotingTo {
 
     function _setReceiver(uint256 _ballotId, address _value) private {
         addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, RECEIVER))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, RECEIVER))
         ] = _value;
     }
 
     function _setSendVotes(uint256 _ballotId, uint256 _value) private {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, SEND_VOTES))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, SEND_VOTES))
         ] = _value;
     }
 }

--- a/contracts/abstracts/VotingTo.sol
+++ b/contracts/abstracts/VotingTo.sol
@@ -80,13 +80,13 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
 
     function getMinThresholdOfVoters(uint256 _id) public view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, MIN_THRESHOLD_OF_VOTERS))
+            keccak256(abi.encode(VOTING_STATE, _id, MIN_THRESHOLD_OF_VOTERS))
         ];
     }
 
     function getQuorumState(uint256 _id) public view returns(uint8) {
         return uint8(uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, QUORUM_STATE))
+            keccak256(abi.encode(VOTING_STATE, _id, QUORUM_STATE))
         ]);
     }
 
@@ -158,13 +158,13 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
 
     function _getCreator(uint256 _id) internal view returns(address) {
         return addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, CREATOR))
+            keccak256(abi.encode(VOTING_STATE, _id, CREATOR))
         ];
     }
 
     function _getEndTime(uint256 _id) internal view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, END_TIME))
+            keccak256(abi.encode(VOTING_STATE, _id, END_TIME))
         ];
     }
 
@@ -175,7 +175,7 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
 
     function _getIsFinalized(uint256 _id) internal view returns(bool) {
         return boolStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, IS_FINALIZED))
+            keccak256(abi.encode(VOTING_STATE, _id, IS_FINALIZED))
         ];
     }
 
@@ -185,7 +185,7 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
 
     function _getMemo(uint256 _id) internal view returns(string) {
         return stringStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, MEMO))
+            keccak256(abi.encode(VOTING_STATE, _id, MEMO))
         ];
     }
 
@@ -196,7 +196,7 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
 
     function _getStartTime(uint256 _id) internal view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, START_TIME))
+            keccak256(abi.encode(VOTING_STATE, _id, START_TIME))
         ];
     }
 
@@ -206,37 +206,37 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
         returns(bool)
     {
         return boolStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _id, VOTERS, _miningKey))
+            keccak256(abi.encode(VOTING_STATE, _id, VOTERS, _miningKey))
         ];
     }
 
     function _setCreator(uint256 _ballotId, address _value) internal {
         addressStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, CREATOR))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, CREATOR))
         ] = _value;
     }
 
     function _setEndTime(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, END_TIME))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, END_TIME))
         ] = _value;
     }
 
     function _setIsFinalized(uint256 _ballotId, bool _value) internal {
         boolStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, IS_FINALIZED))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, IS_FINALIZED))
         ] = _value;
     }
 
     function _setMemo(uint256 _ballotId, string _value) internal {
         stringStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, MEMO))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, MEMO))
         ] = _value;
     }
 
     function _setMinThresholdOfVoters(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, MIN_THRESHOLD_OF_VOTERS))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, MIN_THRESHOLD_OF_VOTERS))
         ] = _value;
     }
 
@@ -246,19 +246,19 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
 
     function _setQuorumState(uint256 _ballotId, uint8 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, QUORUM_STATE))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, QUORUM_STATE))
         ] = _value;
     }
 
     function _setStartTime(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, START_TIME))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, START_TIME))
         ] = _value;
     }
 
     function _votersAdd(uint256 _ballotId, address _miningKey) internal {
         boolStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, VOTERS, _miningKey))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, VOTERS, _miningKey))
         ] = true;
     }
 }

--- a/contracts/abstracts/VotingToChange.sol
+++ b/contracts/abstracts/VotingToChange.sol
@@ -47,7 +47,7 @@ contract VotingToChange is IVotingToChange, VotingTo {
     }
 
     function getIndex(uint256 _id) public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, INDEX))];
+        return uintStorage[keccak256(abi.encode(VOTING_STATE, _id, INDEX))];
     }
 
     function init(uint256 _minBallotDuration) public {
@@ -101,7 +101,7 @@ contract VotingToChange is IVotingToChange, VotingTo {
 
     function validatorActiveBallots(address _miningKey) public view returns(uint256) {
         return uintStorage[
-            keccak256(abi.encodePacked(VALIDATOR_ACTIVE_BALLOTS, _miningKey))
+            keccak256(abi.encode(VALIDATOR_ACTIVE_BALLOTS, _miningKey))
         ];
     }
 
@@ -243,16 +243,16 @@ contract VotingToChange is IVotingToChange, VotingTo {
 
     function _getFinalizeCalled(uint256 _id) internal view returns(bool) {
         return boolStorage[
-            keccak256(abi.encodePacked(FINALIZE_CALLED, _id))
+            keccak256(abi.encode(FINALIZE_CALLED, _id))
         ];
     }
 
     function _getProgress(uint256 _id) internal view returns(int) {
-        return intStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, PROGRESS))];
+        return intStorage[keccak256(abi.encode(VOTING_STATE, _id, PROGRESS))];
     }
 
     function _getTotalVoters(uint256 _id) internal view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked(VOTING_STATE, _id, TOTAL_VOTERS))];
+        return uintStorage[keccak256(abi.encode(VOTING_STATE, _id, TOTAL_VOTERS))];
     }
 
     function _increaseValidatorLimit(address _miningKey) internal {
@@ -296,31 +296,31 @@ contract VotingToChange is IVotingToChange, VotingTo {
 
     function _setIndex(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, INDEX))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, INDEX))
         ] = _value;
     }
 
     function _setFinalizeCalled(uint256 _id) internal {
         boolStorage[
-            keccak256(abi.encodePacked(FINALIZE_CALLED, _id))
+            keccak256(abi.encode(FINALIZE_CALLED, _id))
         ] = true;
     }
 
     function _setProgress(uint256 _ballotId, int256 _value) internal {
         intStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, PROGRESS))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, PROGRESS))
         ] = _value;
     }
 
     function _setTotalVoters(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VOTING_STATE, _ballotId, TOTAL_VOTERS))
+            keccak256(abi.encode(VOTING_STATE, _ballotId, TOTAL_VOTERS))
         ] = _value;
     }
 
     function _setValidatorActiveBallots(address _miningKey, uint256 _count) internal {
         uintStorage[
-            keccak256(abi.encodePacked(VALIDATOR_ACTIVE_BALLOTS, _miningKey))
+            keccak256(abi.encode(VALIDATOR_ACTIVE_BALLOTS, _miningKey))
         ] = _count;
     }
 


### PR DESCRIPTION
- (Mandatory) Description
`abi.encodePacked` function has been replaced with `abi.encode` to make bytes sequences for `keccak256` more unique and to reduce hash collision probability.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)