### PR TITLE
(Refactor) Replace returns(address) with returns(interface) in several private functions

### DIFF
--- a/contracts/BallotsStorage.sol
+++ b/contracts/BallotsStorage.sol
@@ -153,7 +153,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         uint256 _affectedKeyType,
         address _miningKey
     ) internal view returns(bool) {
-        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        IKeysManager keysManager = _getKeysManager();
         if (_affectedKeyType == uint256(KeyTypes.MiningKey)) {
             return !keysManager.checkIfMiningExisted(_miningKey, _affectedKey);
         }
@@ -173,7 +173,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         uint256 _affectedKeyType,
         address _miningKey
     ) internal view returns(bool) {
-        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        IKeysManager keysManager = _getKeysManager();
         require(keysManager.isMiningActive(_miningKey));
         if (_affectedKeyType == uint256(KeyTypes.MiningKey)) {
             return true;
@@ -198,7 +198,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         address _miningKey
     ) internal view returns(bool) {
         require(_affectedKey != _miningKey);
-        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        IKeysManager keysManager = _getKeysManager();
         require(keysManager.isMiningActive(_miningKey));
         if (_affectedKeyType == uint256(KeyTypes.MiningKey)) {
             return !keysManager.checkIfMiningExisted(_miningKey, _affectedKey);
@@ -221,8 +221,8 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         boolStorage[INIT_DISABLED] = true;
     }
 
-    function _getKeysManager() internal view returns(address) {
-        return IProxyStorage(proxyStorage()).getKeysManager();
+    function _getKeysManager() internal view returns(IKeysManager) {
+        return IKeysManager(IProxyStorage(proxyStorage()).getKeysManager());
     }
 
     function _getTotalNumberOfValidators() internal view returns(uint256) {

--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -398,7 +398,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setMiningKeyByVoting(votingKey, address(0));
         _setMiningKeyByPayout(payoutKey, address(0));
         _clearMiningKey(_key);
-        IValidatorMetadata(_getValidatorMetadata()).clearMetadata(_key);
+        _getValidatorMetadata().clearMetadata(_key);
         emit MiningKeyChanged(_key, "removed");
         if (votingKey != address(0)) {
             emit VotingKeyChanged(votingKey, _key, "removed");
@@ -446,7 +446,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         _clearMiningKey(_oldMiningKey);
         _setMiningKeyByVoting(votingKey, _key);
         _setMiningKeyByPayout(payoutKey, _key);
-        IValidatorMetadata(_getValidatorMetadata()).moveMetadata(_oldMiningKey, _key);
+        _getValidatorMetadata().moveMetadata(_oldMiningKey, _key);
         emit MiningKeyChanged(_key, "swapped");
         return true;
     }
@@ -494,8 +494,8 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setIsPayoutActive(false, _miningKey);
     }
 
-    function _getValidatorMetadata() private view returns(address) {
-        return IProxyStorage(proxyStorage()).getValidatorMetadata();
+    function _getValidatorMetadata() private view returns(IValidatorMetadata) {
+        return IValidatorMetadata(IProxyStorage(proxyStorage()).getValidatorMetadata());
     }
 
     function _removeVotingKey(address _miningKey) private {

--- a/contracts/VotingToChangeKeys.sol
+++ b/contracts/VotingToChangeKeys.sol
@@ -24,7 +24,7 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange, EnumKeyTypes
         uint256 _ballotType,
         string _memo
     ) public returns(uint256) {
-        require(IBallotsStorage(_getBallotsStorage()).areKeysBallotParamsValid(
+        require(_getBallotsStorage().areKeysBallotParamsValid(
             _ballotType,
             _affectedKey,
             _affectedKeyType,
@@ -46,7 +46,7 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange, EnumKeyTypes
         address _newPayoutKey,
         string _memo
     ) public returns(uint256) {
-        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        IKeysManager keysManager = _getKeysManager();
         require(keysManager.miningKeyByVoting(_newVotingKey) == address(0));
         require(keysManager.miningKeyByPayout(_newPayoutKey) == address(0));
         require(_newVotingKey != _newMiningKey);
@@ -129,7 +129,7 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange, EnumKeyTypes
 
     // solhint-disable code-complexity
     function _finalizeAdding(uint256 _id) internal returns(bool) {
-        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        IKeysManager keysManager = _getKeysManager();
 
         address affectedKey = _getAffectedKey(_id);
         uint256 affectedKeyType = _getAffectedKeyType(_id);
@@ -186,7 +186,7 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange, EnumKeyTypes
     }
 
     function _finalizeRemoval(uint256 _id) internal returns(bool) {
-        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        IKeysManager keysManager = _getKeysManager();
         uint256 affectedKeyType = _getAffectedKeyType(_id);
         if (affectedKeyType == uint256(KeyTypes.MiningKey)) {
             return keysManager.removeMiningKey(_getAffectedKey(_id));
@@ -199,7 +199,7 @@ contract VotingToChangeKeys is IVotingToChangeKeys, VotingToChange, EnumKeyTypes
     }
 
     function _finalizeSwap(uint256 _id) internal returns(bool) {
-        IKeysManager keysManager = IKeysManager(_getKeysManager());
+        IKeysManager keysManager = _getKeysManager();
         uint256 affectedKeyType = _getAffectedKeyType(_id);
         if (affectedKeyType == uint256(KeyTypes.MiningKey)) {
             return keysManager.swapMiningKey(_getAffectedKey(_id), _getMiningKey(_id));

--- a/contracts/VotingToChangeMinThreshold.sol
+++ b/contracts/VotingToChangeMinThreshold.sol
@@ -15,10 +15,9 @@ contract VotingToChangeMinThreshold is IVotingToChangeMinThreshold, VotingToChan
         uint256 _proposedValue,
         string _memo
     ) public {
-        IBallotsStorage ballotsStorage = IBallotsStorage(_getBallotsStorage());
         require(_proposedValue >= minPossibleThreshold());
         require(_proposedValue != _getGlobalMinThresholdOfVoters());
-        require(_proposedValue <= ballotsStorage.getProxyThreshold());
+        require(_proposedValue <= _getBallotsStorage().getProxyThreshold());
         uint256 ballotId = _createBallot(
             uint256(BallotTypes.MinThreshold),
             _startTime,
@@ -89,8 +88,10 @@ contract VotingToChangeMinThreshold is IVotingToChangeMinThreshold, VotingToChan
     }
 
     function _finalizeBallotInner(uint256 _id) internal returns(bool) {
-        IBallotsStorage ballotsStorage = IBallotsStorage(_getBallotsStorage());
-        return ballotsStorage.setThreshold(_getProposedValue(_id), uint8(ThresholdTypes.Keys));
+        return _getBallotsStorage().setThreshold(
+            _getProposedValue(_id),
+            uint8(ThresholdTypes.Keys)
+        );
     }
 
     function _getProposedValue(uint256 _id) internal view returns(uint256) {

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -92,8 +92,7 @@ contract VotingToChangeProxyAddress is IVotingToChangeProxyAddress, VotingToChan
     }
 
     function _getGlobalMinThresholdOfVoters() internal view returns(uint256) {
-        IBallotsStorage ballotsStorage = IBallotsStorage(_getBallotsStorage());
-        return ballotsStorage.getProxyThreshold();
+        return _getBallotsStorage().getProxyThreshold();
     }
 
     function _getProposedValue(uint256 _id) internal view returns(address) {

--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -52,7 +52,7 @@ contract VotingToManageEmissionFunds is VotingTo {
             _endTime,
             _memo,
             uint8(QuorumStates.InProgress),
-            _getMiningByVotingKey(msg.sender)
+            _getKeysManager().getMiningKeyByVoting(msg.sender)
         );
         _setSendVotes(ballotId, 0);
         _setBurnVotes(ballotId, 0);
@@ -189,7 +189,7 @@ contract VotingToManageEmissionFunds is VotingTo {
         } else {
             revert();
         }
-        address miningKey = _getMiningByVotingKey(msg.sender);
+        address miningKey = _getKeysManager().getMiningKeyByVoting(msg.sender);
         _votersAdd(_id, miningKey);
         emit Vote(_id, _choice, msg.sender, getTime(), miningKey);
 
@@ -261,8 +261,7 @@ contract VotingToManageEmissionFunds is VotingTo {
     // solhint-enable code-complexity, function-max-lines
 
     function _getGlobalMinThresholdOfVoters() internal view returns(uint256) {
-        IBallotsStorage ballotsStorage = IBallotsStorage(_getBallotsStorage());
-        return ballotsStorage.getProxyThreshold();
+        return _getBallotsStorage().getProxyThreshold();
     }
 
     function _max(uint256 a, uint256 b, uint256 c) private pure returns(uint256) {

--- a/contracts/abstracts/VotingToChange.sol
+++ b/contracts/abstracts/VotingToChange.sol
@@ -107,7 +107,7 @@ contract VotingToChange is IVotingToChange, VotingTo {
 
     function vote(uint256 _id, uint8 _choice) public onlyValidVotingKey(msg.sender) {
         require(!_getIsFinalized(_id));
-        address miningKey = _getMiningByVotingKey(msg.sender);
+        address miningKey = _getKeysManager().getMiningKeyByVoting(msg.sender);
         require(isValidVote(_id, msg.sender));
         if (_choice == uint(ActionChoice.Accept)) {
             _setProgress(_id, _getProgress(_id) + 1);
@@ -175,7 +175,7 @@ contract VotingToChange is IVotingToChange, VotingTo {
         returns(uint256)
     {
         require(initDisabled());
-        address creatorMiningKey = _getMiningByVotingKey(msg.sender);
+        address creatorMiningKey = _getKeysManager().getMiningKeyByVoting(msg.sender);
         require(_withinLimit(creatorMiningKey));
         uint256 ballotId = super._createBallot(
             _ballotType,
@@ -237,8 +237,7 @@ contract VotingToChange is IVotingToChange, VotingTo {
     function _finalizeBallotInner(uint256 _id) internal returns(bool);
 
     function _getBallotLimitPerValidator() internal view returns(uint256) {
-        IBallotsStorage ballotsStorage = IBallotsStorage(_getBallotsStorage());
-        return ballotsStorage.getBallotLimitPerValidator();
+        return _getBallotsStorage().getBallotLimitPerValidator();
     }
 
     function _getFinalizeCalled(uint256 _id) internal view returns(bool) {

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -555,10 +555,10 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
 
   describe('#migrate', async () => {
     it('should copy a ballot to the new contract', async () => {
-      proxyStorageMock.setVotingContractMock(accounts[0]);
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
       await addMiningKey(accounts[1]);
       await addVotingKey(votingKey, accounts[1]);
-      proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
+      await proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
 

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -562,10 +562,10 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
 
   describe('#migrate', async () => {
     it('should copy a ballot to the new contract', async () => {
-      proxyStorageMock.setVotingContractMock(accounts[0]);
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
       await addMiningKey(accounts[1]);
       await addVotingKey(votingKey, accounts[1]);
-      proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
+      await proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
 


### PR DESCRIPTION
**(Mandatory) Description**

Some private functions had been returning an address of contract instead of an interface. For example:

```
function _getBallotsStorage() internal view returns(address) {
    return IProxyStorage(proxyStorage()).getBallotsStorage();
}
```

Returning of address was replaced with returning of interface for the above cases to make the code more type-safe:

```
function _getBallotsStorage() internal view returns(IBallotsStorage) {
    return IBallotsStorage(IProxyStorage(proxyStorage()).getBallotsStorage());
}
```

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Refactor)