### PR TITLE
(Refactor) Move `implementation` and `version` functions from `EternalStorage` to `EternalStorageProxy`

### DIFF
--- a/contracts/eternal-storage/EternalStorage.sol
+++ b/contracts/eternal-storage/EternalStorage.sol
@@ -31,20 +31,4 @@ contract EternalStorage {
     mapping(bytes32 => int256[]) internal intArrayStorage;
     mapping(bytes32 => bytes32[]) internal bytes32ArrayStorage;
 
-    /**
-    * @dev Tells the version number of the current implementation
-    * @return uint representing the number of the current version
-    */
-    function version() public view returns (uint256) {
-        return _version;
-    }
-
-    /**
-    * @dev Tells the address of the current implementation
-    * @return address of the current implementation
-    */
-    function implementation() public view returns (address) {
-        return _implementation;
-    }
-
 }

--- a/contracts/eternal-storage/EternalStorageProxy.sol
+++ b/contracts/eternal-storage/EternalStorageProxy.sol
@@ -85,6 +85,14 @@ contract EternalStorageProxy is EternalStorage {
     }
 
     /**
+    * @dev Tells the address of the current implementation
+    * @return address of the current implementation
+    */
+    function implementation() public view returns(address) {
+        return _implementation;
+    }
+
+    /**
      * @dev Allows the current owner to relinquish ownership.
      */
     function renounceOwnership() public onlyOwner {
@@ -118,6 +126,14 @@ contract EternalStorageProxy is EternalStorage {
 
         emit Upgraded(_version, _implementation);
         return true;
+    }
+
+    /**
+    * @dev Tells the version number of the current implementation
+    * @return uint representing the number of the current version
+    */
+    function version() public view returns(uint256) {
+        return _version;
     }
 
     function _setProxyStorage(address _proxyStorage) private {

--- a/test/emission_funds_test.js
+++ b/test/emission_funds_test.js
@@ -61,7 +61,7 @@ contract('EmissionFunds [all features]', function (accounts) {
       receiverInitBalance = await web3.eth.getBalance(receiver);
     });
 
-    it('may be called only by VotingToManageEmissionFunds', async () => {
+    it('may only be called by VotingToManageEmissionFunds', async () => {
       const amountToSend = web3.toWei(5, 'ether');
       await emissionFunds.sendFundsTo(
         receiver,
@@ -236,7 +236,7 @@ contract('EmissionFunds [all features]', function (accounts) {
   });
 
   describe('#burnFunds', async () => {
-    it('may be called only by VotingToManageEmissionFunds', async () => {
+    it('may only be called by VotingToManageEmissionFunds', async () => {
       const amountToBurn = web3.toWei(5, 'ether');
       await emissionFunds.burnFunds(
         amountToBurn,
@@ -337,7 +337,7 @@ contract('EmissionFunds [all features]', function (accounts) {
   });
 
   describe('#freezeFunds', async () => {
-    it('may be called only by VotingToManageEmissionFunds', async () => {
+    it('may only be called by VotingToManageEmissionFunds', async () => {
       const amountToFreeze = web3.toWei(5, 'ether');
       await emissionFunds.freezeFunds(
         amountToFreeze,

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -569,9 +569,11 @@ contract('ValidatorMetadata [all features]', function (accounts) {
 
   describe('#upgradeTo', async () => {
     let proxyStorageStubAddress;
+    let metadataOldImplementation;
     beforeEach(async () => {
       proxyStorageStubAddress = accounts[8];
       metadata = await ValidatorMetadata.new();
+      metadataOldImplementation = metadata.address;
       metadataEternalStorage = await EternalStorageProxy.new(proxyStorageStubAddress, metadata.address);
       metadata = await ValidatorMetadata.at(metadataEternalStorage.address);
     });
@@ -582,22 +584,16 @@ contract('ValidatorMetadata [all features]', function (accounts) {
     });
     it('should change implementation address', async () => {
       let metadataNew = await ValidatorMetadataNew.new();
-      let oldImplementation = await metadata.implementation.call();
       let newImplementation = metadataNew.address;
-      (await metadataEternalStorage.implementation.call()).should.be.equal(oldImplementation);
+      (await metadataEternalStorage.implementation.call()).should.be.equal(metadataOldImplementation);
       await upgradeTo(newImplementation, {from: proxyStorageStubAddress});
-      metadataNew = await ValidatorMetadataNew.at(metadataEternalStorage.address);
-      (await metadataNew.implementation.call()).should.be.equal(newImplementation);
       (await metadataEternalStorage.implementation.call()).should.be.equal(newImplementation);
     });
     it('should increment implementation version', async () => {
       let metadataNew = await ValidatorMetadataNew.new();
-      let oldVersion = await metadata.version.call();
+      let oldVersion = await metadataEternalStorage.version.call();
       let newVersion = oldVersion.add(1);
-      (await metadataEternalStorage.version.call()).should.be.bignumber.equal(oldVersion);
       await upgradeTo(metadataNew.address, {from: proxyStorageStubAddress});
-      metadataNew = await ValidatorMetadataNew.at(metadataEternalStorage.address);
-      (await metadataNew.version.call()).should.be.bignumber.equal(newVersion);
       (await metadataEternalStorage.version.call()).should.be.bignumber.equal(newVersion);
     });
     it('new implementation should work', async () => {

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -261,7 +261,7 @@ contract('ProxyStorage [all features]', function (accounts) {
       )
     })
     it('changes proxyStorage (itself) implementation', async () => {
-      const oldVersion = await proxyStorage.version.call();
+      const oldVersion = await proxyStorageEternalStorage.version.call();
       const newVersion = oldVersion.add(1);
       let proxyStorageNew = await ProxyStorageMock.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
@@ -271,15 +271,8 @@ contract('ProxyStorage [all features]', function (accounts) {
       proxyStorageNew.address.should.be.equal(
         await proxyStorageEternalStorage.implementation.call()
       );
-      proxyStorageNew.address.should.be.equal(
-        await proxyStorage.implementation.call()
-      );
       newVersion.should.be.bignumber.equal(
         await proxyStorageEternalStorage.version.call()
-      );
-      proxyStorageNew = await ProxyStorageMock.at(proxyStorageEternalStorage.address);
-      newVersion.should.be.bignumber.equal(
-        await proxyStorageNew.version.call()
       );
     })
   })
@@ -307,14 +300,11 @@ contract('ProxyStorage [all features]', function (accounts) {
     });
     it('should increment implementation version', async () => {
       let proxyStorageNew = await ProxyStorageNew.new();
-      const oldVersion = await proxyStorage.version.call();
+      const oldVersion = await proxyStorageEternalStorage.version.call();
       const newVersion = oldVersion.add(1);
-      (await proxyStorageEternalStorage.version.call()).should.be.bignumber.equal(oldVersion);
       await proxyStorageEternalStorage.setProxyStorage(accounts[0]);
       await upgradeTo(proxyStorageNew.address, {from: accounts[0]});
       await proxyStorageEternalStorage.setProxyStorage(proxyStorageEternalStorage.address);
-      proxyStorageNew = await ProxyStorageNew.at(proxyStorageEternalStorage.address);
-      (await proxyStorageNew.version.call()).should.be.bignumber.equal(newVersion);
       (await proxyStorageEternalStorage.version.call()).should.be.bignumber.equal(newVersion);
     });
     it('new implementation should work', async () => {

--- a/test/proxy_storage_upgrade_test.js
+++ b/test/proxy_storage_upgrade_test.js
@@ -268,7 +268,7 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
       )
     })
     it('changes proxyStorage (itself) implementation', async () => {
-      const oldVersion = await proxyStorage.version.call();
+      const oldVersion = await proxyStorageEternalStorage.version.call();
       const newVersion = oldVersion.add(1);
       let proxyStorageNew = await ProxyStorageMock.new();
       await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
@@ -278,15 +278,8 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
       proxyStorageNew.address.should.be.equal(
         await proxyStorageEternalStorage.implementation.call()
       );
-      proxyStorageNew.address.should.be.equal(
-        await proxyStorage.implementation.call()
-      );
       newVersion.should.be.bignumber.equal(
         await proxyStorageEternalStorage.version.call()
-      );
-      proxyStorageNew = await ProxyStorageMock.at(proxyStorageEternalStorage.address);
-      newVersion.should.be.bignumber.equal(
-        await proxyStorageNew.version.call()
       );
     })
   })

--- a/test/reward_by_block_upgrade_test.js
+++ b/test/reward_by_block_upgrade_test.js
@@ -224,7 +224,7 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
   });
 
   describe('#addExtraReceiver', async () => {
-    it('may be called only by bridge contract', async () => {
+    it('may only be called by bridge contract', async () => {
       await rewardByBlock.addExtraReceiver(accounts[1], 1).should.be.rejectedWith(ERROR_MSG);
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(accounts[1], 1, {from: accounts[2]}).should.be.fulfilled;

--- a/test/reward_by_time_upgrade_test.js
+++ b/test/reward_by_time_upgrade_test.js
@@ -100,7 +100,7 @@ contract('RewardByTime upgraded [all features]', function (accounts) {
   });
 
   describe('#reward', async () => {
-    it('may be called only by system address', async () => {
+    it('may only be called by system address', async () => {
       await rewardByTime.reward().should.be.rejectedWith(ERROR_MSG);
       await rewardByTime.setSystemAddress(systemAddress);
       await rewardByTime.reward({from: systemAddress}).should.be.fulfilled;

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -26,6 +26,7 @@ require('chai')
 let keysManager, poaNetworkConsensusMock, ballotsStorage, voting, votingEternalStorage;
 let votingKey, votingKey2, votingKey3, miningKeyForVotingKey;
 let votingForKeysEternalStorage;
+let proxyStorageMock, proxyStorageEternalStorage;
 let VOTING_START_DATE, VOTING_END_DATE;
 contract('VotingToChangeProxyAddress upgraded [all features]', function (accounts) {
   beforeEach(async () => {
@@ -36,7 +37,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
     poaNetworkConsensusMock = await PoaNetworkConsensusMock.new(masterOfCeremony, []);
     
     proxyStorageMock = await ProxyStorageMock.new();
-    const proxyStorageEternalStorage = await EternalStorageProxy.new(0, proxyStorageMock.address);
+    proxyStorageEternalStorage = await EternalStorageProxy.new(0, proxyStorageMock.address);
     proxyStorageMock = await ProxyStorageMock.at(proxyStorageEternalStorage.address);
     await proxyStorageMock.init(poaNetworkConsensusMock.address).should.be.fulfilled;
 
@@ -426,7 +427,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       const proxyStorageNew = await ProxyStorageMock.new();
       const newAddress = proxyStorageNew.address;
       await deployAndTest({contractType, newAddress})
-      newAddress.should.be.equal(await proxyStorageMock.implementation.call());
+      newAddress.should.be.equal(await proxyStorageEternalStorage.implementation.call());
     })
     it('prevents double finalize', async () => {
       let newAddress1 = accounts[4];

--- a/test/voting_to_manage_emission_funds_test.js
+++ b/test/voting_to_manage_emission_funds_test.js
@@ -764,9 +764,11 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
 
   describe('#upgradeTo', async () => {
     let proxyStorageStubAddress;
+    let votingOldImplementation;
     beforeEach(async () => {
       proxyStorageStubAddress = accounts[8];
       voting = await VotingToManageEmissionFunds.new();
+      votingOldImplementation = voting.address;
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageStubAddress, voting.address);
       voting = await VotingToManageEmissionFunds.at(votingEternalStorage.address);
       await voting.init(
@@ -783,22 +785,16 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
     });
     it('should change implementation address', async () => {
       let votingNew = await VotingToManageEmissionFundsNew.new();
-      let oldImplementation = await voting.implementation.call();
       let newImplementation = votingNew.address;
-      (await votingEternalStorage.implementation.call()).should.be.equal(oldImplementation);
+      (await votingEternalStorage.implementation.call()).should.be.equal(votingOldImplementation);
       await upgradeTo(newImplementation, {from: proxyStorageStubAddress});
-      votingNew = await VotingToManageEmissionFundsNew.at(votingEternalStorage.address);
-      (await votingNew.implementation.call()).should.be.equal(newImplementation);
       (await votingEternalStorage.implementation.call()).should.be.equal(newImplementation);
     });
     it('should increment implementation version', async () => {
       let votingNew = await VotingToManageEmissionFundsNew.new();
-      let oldVersion = await voting.version.call();
+      let oldVersion = await votingEternalStorage.version.call();
       let newVersion = oldVersion.add(1);
-      (await votingEternalStorage.version.call()).should.be.bignumber.equal(oldVersion);
       await upgradeTo(votingNew.address, {from: proxyStorageStubAddress});
-      votingNew = await VotingToManageEmissionFundsNew.at(votingEternalStorage.address);
-      (await votingNew.version.call()).should.be.bignumber.equal(newVersion);
       (await votingEternalStorage.version.call()).should.be.bignumber.equal(newVersion);
     });
     it('new implementation should work', async () => {


### PR DESCRIPTION
- (Mandatory) Description
`implementation` and `version` functions have been moved from `EternalStorage` to `EternalStorageProxy` contract. Thus, they are removed from implementations and available only in `EternalStorageProxy`.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Refactor)