### PR TITLE
(Fix) Accounting of pending confirmations in ValidatorMetadata's `moveMetadata` and `clearMetadata` functions

### DIFF
--- a/contracts/eternal-storage/EternalStorageProxy.sol
+++ b/contracts/eternal-storage/EternalStorageProxy.sol
@@ -112,19 +112,19 @@ contract EternalStorageProxy is EternalStorage {
 
     /**
      * @dev Allows ProxyStorage contract to upgrade the current implementation.
-     * @param implementation representing the address of the new implementation to be set.
+     * @param newImplementation representing the address of the new implementation to be set.
      */
-    function upgradeTo(address implementation) public onlyProxyStorage returns(bool) {
-        if (implementation == address(0)) return false;
-        if (_implementation == implementation) return false;
+    function upgradeTo(address newImplementation) public onlyProxyStorage returns(bool) {
+        if (newImplementation == address(0)) return false;
+        if (_implementation == newImplementation) return false;
 
-        uint256 _newVersion = _version + 1;
-        if (_newVersion <= _version) return false;
+        uint256 newVersion = _version + 1;
+        if (newVersion <= _version) return false;
 
-        _version = _newVersion;
-        _implementation = implementation;
+        _version = newVersion;
+        _implementation = newImplementation;
 
-        emit Upgraded(_version, _implementation);
+        emit Upgraded(newVersion, newImplementation);
         return true;
     }
 

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -164,11 +164,19 @@ contract('ValidatorMetadata [all features]', function (accounts) {
       result.logs[0].event.should.be.equal("ChangeRequestInitiated");
       result.logs[0].args.miningKey.should.be.equal(miningKey);
 
+      await metadata.confirmPendingChange(miningKey, {from: votingKey2}).should.be.fulfilled;
+      let confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
+      confirmations[1][0].should.be.equal(miningKey2); // voters array
+
       await proxyStorageMock.setKeysManagerMock(accounts[0]);
       result = await metadata.clearMetadata(miningKey);
       result.logs[0].event.should.be.equal('MetadataCleared');
       result.logs[0].args.miningKey.should.be.equal(miningKey);
       await proxyStorageMock.setKeysManagerMock(keysManager.address);
+
+      confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(0); // voters count
 
       (await metadata.validators.call(miningKey)).should.be.deep.equal([
         toHex(""),
@@ -233,6 +241,11 @@ contract('ValidatorMetadata [all features]', function (accounts) {
       result.logs[0].event.should.be.equal("ChangeRequestInitiated");
       result.logs[0].args.miningKey.should.be.equal(miningKey);
 
+      await metadata.confirmPendingChange(miningKey, {from: votingKey3}).should.be.fulfilled;
+      let confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
+      confirmations[1][0].should.be.equal(miningKey3); // voters array
+
       (await metadata.validators.call(miningKey2)).should.be.deep.equal([
         toHex(""),
         toHex(""),
@@ -266,6 +279,9 @@ contract('ValidatorMetadata [all features]', function (accounts) {
       result.logs[0].args.newMiningKey.should.be.equal(miningKey2);
       await proxyStorageMock.setKeysManagerMock(keysManager.address);
 
+      confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(0); // voters count
+
       (await metadata.validators.call(miningKey)).should.be.deep.equal([
         toHex(""),
         toHex(""),
@@ -291,6 +307,10 @@ contract('ValidatorMetadata [all features]', function (accounts) {
         new web3.BigNumber(0),
         new web3.BigNumber(0)
       ]);
+
+      confirmations = await metadata.confirmations.call(miningKey2);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
+      confirmations[1][0].should.be.equal(miningKey3); // voters array
 
       (await metadata.validators.call(miningKey2)).should.be.deep.equal([
         toHex("Djamshut"),

--- a/test/metadata_upgrade_test.js
+++ b/test/metadata_upgrade_test.js
@@ -171,11 +171,19 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       result.logs[0].event.should.be.equal("ChangeRequestInitiated");
       result.logs[0].args.miningKey.should.be.equal(miningKey);
 
+      await metadata.confirmPendingChange(miningKey, {from: votingKey2}).should.be.fulfilled;
+      let confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
+      confirmations[1][0].should.be.equal(miningKey2); // voters array
+
       await proxyStorageMock.setKeysManagerMock(accounts[0]);
       result = await metadata.clearMetadata(miningKey);
       result.logs[0].event.should.be.equal('MetadataCleared');
       result.logs[0].args.miningKey.should.be.equal(miningKey);
       await proxyStorageMock.setKeysManagerMock(keysManager.address);
+
+      confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(0); // voters count
 
       (await metadata.validators.call(miningKey)).should.be.deep.equal([
         toHex(""),
@@ -240,6 +248,11 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       result.logs[0].event.should.be.equal("ChangeRequestInitiated");
       result.logs[0].args.miningKey.should.be.equal(miningKey);
 
+      await metadata.confirmPendingChange(miningKey, {from: votingKey3}).should.be.fulfilled;
+      let confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
+      confirmations[1][0].should.be.equal(miningKey3); // voters array
+
       (await metadata.validators.call(miningKey2)).should.be.deep.equal([
         toHex(""),
         toHex(""),
@@ -273,6 +286,9 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       result.logs[0].args.newMiningKey.should.be.equal(miningKey2);
       await proxyStorageMock.setKeysManagerMock(keysManager.address);
 
+      confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(0); // voters count
+
       (await metadata.validators.call(miningKey)).should.be.deep.equal([
         toHex(""),
         toHex(""),
@@ -298,6 +314,10 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
         new web3.BigNumber(0),
         new web3.BigNumber(0)
       ]);
+
+      confirmations = await metadata.confirmations.call(miningKey2);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
+      confirmations[1][0].should.be.equal(miningKey3); // voters array
 
       (await metadata.validators.call(miningKey2)).should.be.deep.equal([
         toHex("Djamshut"),


### PR DESCRIPTION
- (Mandatory) Description
`ValidatorMetadata.moveMetadata` and `ValidatorMetadata.clearMetadata` functions now take into account pending confirmations if they are existed: `moveMetadata` moves confirmations from an old mining key to a new mining key, `clearMetadata` removes confirmations for a specified mining key.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)