### PR TITLE
(Feature) Checking if a voting key is EOA or a contract

### DIFF
--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -204,6 +204,8 @@ contract VotingToManageEmissionFunds is VotingTo {
 
     // solhint-disable code-complexity, function-max-lines
     function _finalize(uint256 _id) internal {
+        require(_isEOA(msg.sender));
+
         IEmissionFunds _emissionFunds = IEmissionFunds(emissionFunds());
         uint256 amount = getAmount(_id);
 
@@ -262,6 +264,12 @@ contract VotingToManageEmissionFunds is VotingTo {
 
     function _getGlobalMinThresholdOfVoters() internal view returns(uint256) {
         return _getBallotsStorage().getProxyThreshold();
+    }
+
+    function _isEOA(address addr) internal view returns (bool) {
+        uint256 size;
+        assembly { size := extcodesize(addr) }
+        return size == 0;
     }
 
     function _max(uint256 a, uint256 b, uint256 c) private pure returns(uint256) {

--- a/test/utilContracts/VotingKey.sol
+++ b/test/utilContracts/VotingKey.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.24;
+
+
+interface IVotingTo {
+    function finalize(uint256) external;
+}
+
+
+contract VotingKey {
+	IVotingTo public votingTo;
+
+    constructor(address _votingTo) public {
+    	votingTo = IVotingTo(_votingTo);
+    }
+
+    function callFinalize(uint256 _id) public {
+    	votingTo.finalize(_id);
+    }
+}

--- a/test/voting_to_manage_emission_funds_upgrade_test.js
+++ b/test/voting_to_manage_emission_funds_upgrade_test.js
@@ -11,6 +11,7 @@ const VotingForMinThreshold = artifacts.require('./mockContracts/VotingToChangeM
 const VotingForProxy = artifacts.require('./mockContracts/VotingToChangeProxyAddressMock');
 const VotingToManageEmissionFunds = artifacts.require('./mockContracts/VotingToManageEmissionFundsMock');
 const VotingToManageEmissionFundsNew = artifacts.require('./upgradeContracts/VotingToManageEmissionFundsNew');
+const VotingKey = artifacts.require('./utilContracts/VotingKey');
 
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 
@@ -498,18 +499,18 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       await voting.vote(id, choice.send, {from: votingKey}).should.be.fulfilled;
       false.should.be.equal((await voting.getBallotInfo.call(id, votingKey))[2]); // isFinalized
 
-      proxyStorage.setVotingContractMock(coinbase);
+      await proxyStorage.setVotingContractMock(coinbase);
       const {logs} = await keysManager.swapMiningKey(miningKey3, miningKey);
       logs[0].event.should.equal("MiningKeyChanged");
-      proxyStorage.setVotingContractMock(votingForKeysEternalStorage.address);
+      await proxyStorage.setVotingContractMock(votingForKeysEternalStorage.address);
       await poaNetworkConsensus.setSystemAddress(coinbase);
       await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
       await poaNetworkConsensus.setSystemAddress('0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE');
       await voting.vote(id, choice.send, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
 
-      proxyStorage.setVotingContractMock(coinbase);
+      await proxyStorage.setVotingContractMock(coinbase);
       await swapVotingKey(votingKey3, miningKey3);
-      proxyStorage.setVotingContractMock(votingForKeysEternalStorage.address);
+      await proxyStorage.setVotingContractMock(votingForKeysEternalStorage.address);
       await voting.vote(id, choice.send, {from: votingKey3}).should.be.rejectedWith(ERROR_MSG);
 
       await voting.vote(id, choice.send, {from: votingKey2}).should.be.fulfilled;
@@ -527,11 +528,11 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       await voting.vote(id, choice.send, {from: votingKey3}).should.be.fulfilled;
       false.should.be.equal((await voting.getBallotInfo.call(id, votingKey))[2]); // isFinalized
 
-      proxyStorage.setVotingContractMock(coinbase);
+      await proxyStorage.setVotingContractMock(coinbase);
       let result = await keysManager.swapMiningKey(miningKey, miningKey3);
       result.logs[0].event.should.equal("MiningKeyChanged");
       await swapVotingKey(votingKey, miningKey);
-      proxyStorage.setVotingContractMock(votingForKeysEternalStorage.address);
+      await proxyStorage.setVotingContractMock(votingForKeysEternalStorage.address);
       await poaNetworkConsensus.setSystemAddress(coinbase);
       await poaNetworkConsensus.finalizeChange().should.be.fulfilled;
       await poaNetworkConsensus.setSystemAddress('0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE');
@@ -763,6 +764,32 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       );
       await voting.setTime(VOTING_END_DATE + 1);
       await voting.finalize(0, {from: votingKey}).should.be.fulfilled;
+      (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(
+        emissionReleaseTime + emissionReleaseThreshold
+      );
+    });
+
+    it('deny finalization if the voting key is a contract', async () => {
+      const voter = await VotingKey.new(voting.address);
+      votingKey2 = voter.address;
+
+      await voting.createBallot(
+        VOTING_START_DATE, VOTING_END_DATE, receiver, "memo", {from: votingKey}
+      ).should.be.fulfilled;
+
+      false.should.be.equal((await voting.getBallotInfo.call(id, votingKey))[2]); // isFinalized
+      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+
+      await addValidator(votingKey2, miningKey2);
+      await voting.setTime(VOTING_END_DATE + 1);
+      
+      await voter.callFinalize(id).should.be.rejectedWith(ERROR_MSG);
+      false.should.be.equal((await voting.getBallotInfo.call(id, votingKey))[2]); // isFinalized
+
+      await voting.finalize(id, {from: votingKey}).should.be.fulfilled;
+      true.should.be.equal((await voting.getBallotInfo.call(id, votingKey))[2]); // isFinalized
+
+      (await voting.previousBallotFinalized.call()).should.be.equal(true);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(
         emissionReleaseTime + emissionReleaseThreshold
       );


### PR DESCRIPTION
**(Mandatory) Description**

`VotingToManageEmissionFunds._finalize` private function has been complemented with checking whether a voting key is an EOA (externally owned account) or a contract. This is necessary to prevent stack overflow when a ballot is being finalized and when `EmissionFunds` functions are consequently being called. `extcodesize` opcode is used for this checking:

```
function _isEOA(address addr) internal view returns (bool) {
    uint256 size;
    assembly { size := extcodesize(addr) }
    return size == 0;
}
```

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Feature)