### PR TITLE
(Fix) Improving of BallotsStorage.init, BallotsStorage.setThreshold and ValidatorMetadata.confirmPendingChange functions

### DIFF
--- a/contracts/ValidatorMetadata.sol
+++ b/contracts/ValidatorMetadata.sol
@@ -272,11 +272,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         require(voterMiningKey != _miningKey);
         require(!isValidatorAlreadyVoted(_miningKey, voterMiningKey));
 
-        uint256 confirmationsLimit = 50;
-        uint256 minThreshold = _getMinThreshold(true, _miningKey);
-        if (confirmationsLimit < minThreshold) {
-            confirmationsLimit = minThreshold;
-        }
+        uint256 confirmationsLimit = _getBallotsStorage().metadataChangeConfirmationsLimit();
         require(_getConfirmationsVoters(_miningKey).length < confirmationsLimit);
 
         _confirmationsVoterAdd(_miningKey, voterMiningKey);

--- a/contracts/interfaces/IBallotsStorage.sol
+++ b/contracts/interfaces/IBallotsStorage.sol
@@ -9,4 +9,5 @@ interface IBallotsStorage {
     function getProxyThreshold() external view returns(uint256);
     function getBallotLimitPerValidator() external view returns(uint256);
     function getMaxLimitBallot() external view returns(uint256);
+    function metadataChangeConfirmationsLimit() external pure returns(uint256);
 }

--- a/test/ballots_storage_test.js
+++ b/test/ballots_storage_test.js
@@ -1,6 +1,6 @@
 let PoaNetworkConsensus = artifacts.require('./mockContracts/PoaNetworkConsensusMock');
 let ProxyStorageMock = artifacts.require('./mockContracts/ProxyStorageMock');
-let BallotsStorage = artifacts.require('./BallotsStorage');
+let BallotsStorage = artifacts.require('./mockContracts/BallotsStorageMock');
 let BallotsStorageNew = artifacts.require('./upgradeContracts/BallotsStorageNew');
 let VotingToChangeMinThresholdMock = artifacts.require('./mockContracts/VotingToChangeMinThresholdMock');
 let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
@@ -41,6 +41,7 @@ contract('BallotsStorage [all features]', function (accounts) {
     ballotsEternalStorage = await EternalStorageProxy.new(proxyStorage.address, ballotsStorage.address);
     ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);
     await ballotsStorage.init([3, 2], {from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+    await ballotsStorage.init([3, 3]).should.be.rejectedWith(ERROR_MSG);
     await ballotsStorage.init([3, 2]).should.be.fulfilled;
 
     keysManager = await KeysManagerMock.new();
@@ -105,20 +106,22 @@ contract('BallotsStorage [all features]', function (accounts) {
       await setThreshold(5, -10, false, {from: accounts[3]});
       await setThreshold(5, -1, false, {from: accounts[3]});
       await setThreshold(5, 3, false, {from: accounts[3]});
+      await setThreshold(3, 2, false, {from: accounts[3]});
     })
     it('new value cannot be equal to 0', async () => {
       await setThreshold(0, 1, false, {from: accounts[3]});
       await setThreshold(0, 2, false, {from: accounts[3]});
       await setThreshold(4, 1, true, {from: accounts[3]});
-      await setThreshold(4, 2, true, {from: accounts[3]});
+      await setThreshold(1, 2, true, {from: accounts[3]});
     })
     it('sets new value for Keys threshold', async () => {
       await setThreshold(5, 1, true, {from: accounts[3]});
       new web3.BigNumber(5).should.be.bignumber.equal(await ballotsStorage.getBallotThreshold.call(1));
     })
     it('sets new value for MetadataChange threshold', async () => {
-      await setThreshold(6, 2, true, {from: accounts[3]});
-      new web3.BigNumber(6).should.be.bignumber.equal(await ballotsStorage.getBallotThreshold.call(2));
+      new web3.BigNumber(2).should.be.bignumber.equal(await ballotsStorage.getBallotThreshold.call(2));
+      await setThreshold(1, 2, true, {from: accounts[3]});
+      new web3.BigNumber(1).should.be.bignumber.equal(await ballotsStorage.getBallotThreshold.call(2));
     })
   })
   describe('#getProxyThreshold', async () => {

--- a/test/metadata_upgrade_test.js
+++ b/test/metadata_upgrade_test.js
@@ -2,7 +2,7 @@ let PoaNetworkConsensusMock = artifacts.require('./mockContracts/PoaNetworkConse
 let KeysManagerMock = artifacts.require('./mockContracts/KeysManagerMock');
 let ValidatorMetadata = artifacts.require('./mockContracts/ValidatorMetadataMock');
 let ValidatorMetadataNew = artifacts.require('./upgradeContracts/ValidatorMetadataNew');
-let BallotsStorage = artifacts.require('./BallotsStorage');
+let BallotsStorage = artifacts.require('./mockContracts/BallotsStorageMock');
 let ProxyStorageMock = artifacts.require('./mockContracts/ProxyStorageMock');
 let EternalStorageProxy = artifacts.require('./mockContracts/EternalStorageProxyMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
@@ -441,13 +441,13 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       await metadata.confirmPendingChange(miningKey, {from: votingKey2});
       await metadata.confirmPendingChange(miningKey, {from: votingKey3});
       let confirmations = await metadata.confirmations.call(miningKey);
-      confirmations[0].should.be.bignumber.equal(2);
+      confirmations[0].should.be.bignumber.equal(2); // voters count
       const {logs} = await metadata.changeRequest(...anotherData, {from: votingKey}).should.be.fulfilled;
       confirmations = await metadata.confirmations.call(miningKey);
-      confirmations[0].should.be.bignumber.equal(0);
+      confirmations[0].should.be.bignumber.equal(0); // voters count
       await metadata.confirmPendingChange(miningKey, {from: votingKey2});
       confirmations = await metadata.confirmations.call(miningKey);
-      confirmations[0].should.be.bignumber.equal(1);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
     })
   })
 
@@ -532,7 +532,7 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       await metadata.changeRequest(...newMetadata, {from: votingKey}).should.be.fulfilled;
       const {logs} = await metadata.confirmPendingChange(miningKey, {from: votingKey2}).should.be.fulfilled;
       const confirmations = await metadata.confirmations.call(miningKey);
-      confirmations[0].should.be.bignumber.equal(1);
+      confirmations[0].should.be.bignumber.equal(1); // voters count
       logs[0].event.should.be.equal('Confirmed');
       logs[0].args.miningKey.should.be.equal(miningKey);
       logs[0].args.votingSender.should.be.equal(votingKey2);
@@ -543,8 +543,21 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       const {logs} = await metadata.confirmPendingChange(miningKey, {from: votingKey2}).should.be.fulfilled;
       await metadata.confirmPendingChange(miningKey, {from: votingKey2}).should.be.rejectedWith(ERROR_MSG);
       const confirmations = await metadata.confirmations.call(miningKey);
-      confirmations[0].should.be.bignumber.equal(1);
-    })
+      confirmations[0].should.be.bignumber.equal(1); // voters count
+    });
+    it('should not exceed confirmations limit', async () => {
+      const miningKey4 = accounts[8];
+      const votingKey4 = accounts[9];
+      await addMiningKey(miningKey4);
+      await addVotingKey(votingKey4, miningKey4);
+      await metadata.createMetadata(...fakeData, {from: votingKey}).should.be.fulfilled;
+      await metadata.changeRequest(...newMetadata, {from: votingKey}).should.be.fulfilled;
+      await metadata.confirmPendingChange(miningKey, {from: votingKey2}).should.be.fulfilled;
+      await metadata.confirmPendingChange(miningKey, {from: votingKey4}).should.be.fulfilled;
+      await metadata.confirmPendingChange(miningKey, {from: votingKey3}).should.be.rejectedWith(ERROR_MSG);
+      const confirmations = await metadata.confirmations.call(miningKey);
+      confirmations[0].should.be.bignumber.equal(2); // voters count
+    });
   });
   describe('#finalize', async ()=> {
     it('happy path', async ()=> {

--- a/test/mockContracts/BallotsStorageMock.sol
+++ b/test/mockContracts/BallotsStorageMock.sol
@@ -4,7 +4,12 @@ import '../../contracts/BallotsStorage.sol';
 
 
 contract BallotsStorageMock is BallotsStorage {
+    function metadataChangeConfirmationsLimit() public pure returns(uint256) {
+        return 2;
+    }
+
     function setThresholdMock(uint256 _newValue, uint8 _thresholdType) public {
         _setThreshold(_newValue, _thresholdType);
     }
+
 }

--- a/test/upgradeContracts/BallotsStorageNew.sol
+++ b/test/upgradeContracts/BallotsStorageNew.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../../contracts/BallotsStorage.sol";
+import '../mockContracts/BallotsStorageMock.sol';
 
 
-contract BallotsStorageNew is BallotsStorage {
+contract BallotsStorageNew is BallotsStorageMock {
   
   function initialize() public {
     boolStorage[keccak256('initialized')] = true;

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -678,10 +678,10 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
       const id = await voting.nextBallotId.call();
-      proxyStorageMock.setVotingContractMock(accounts[0]);
+      await proxyStorageMock.setVotingContractMock(accounts[0]);
       await addMiningKey(miningKeyForVotingKey);
       await addVotingKey(votingKey, miningKeyForVotingKey);
-      proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
+      await proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
       await votingEternalStorage.setProxyStorage(proxyStorageMock.address);
       await voting.createBallot(
         VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }


### PR DESCRIPTION
- (Mandatory) Description
`ValidatorMetadata.confirmPendingChange` function has confirmations' limit of `50`. This is needed to limit cycle iterations inside `ValidatorMetadata._isValidatorAlreadyVoted` and `ValidatorMetadata._confirmationsVotersCopy` private functions. Now `BallotsStorage.init` and `BallotsStorage.setThreshold` functions cannot exceed the value of `50`.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)