### PR TITLE
(Fix) Deny using VotingToChange* functions unless migration is completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,19 @@ Compile and deploy contracts in the next sequence:
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of VotingToChangeKeys contract.
 -  Make a call to `VotingToChangeKeys init` with `_minBallotDuration` parameter equal to `172800`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeKeys`.
+-  Make a call to `VotingToChangeKeys migrateDisable`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeKeys`.
 - `VotingToChangeMinThreshold_flat.sol` - Deploy `VotingToChangeMinThreshold` contract.
 - `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of VotingToChangeMinThreshold contract.
 -  Make a call to `VotingToChangeMinThreshold init` with `_minBallotDuration` parameter equal to `172800` and `_minPossibleThreshold` parameter equal to `3`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeMinThreshold`.
+-  Make a call to `VotingToChangeMinThreshold migrateDisable`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeMinThreshold`.
 - `VotingToChangeProxyAddress_flat.sol` - Deploy `VotingToChangeProxyAddress` contract.
 - `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,
 `_implementationAddress` - address of VotingToChangeProxyAddress contract.
 -  Make a call to `VotingToChangeProxyAddress init` with `_minBallotDuration` parameter equal to `172800`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeProxyAddress`.
+-  Make a call to `VotingToChangeProxyAddress migrateDisable`, using the address of `EternalStorageProxy` and ABI of `VotingToChangeProxyAddress`.
 - `ValidatorMetadata_flat.sol` - Deploy `ValidatorMetadata` contract.
 - `EternalStorageProxy_flat.sol` - Deploy `EternalStorageProxy` contract with constructor parameters: <br />
 `_proxyStorage` - address of ProxyStorage contract,

--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -36,7 +36,6 @@ contract VotingToManageEmissionFunds is VotingTo {
         address _receiver,
         string _memo
     ) public onlyValidVotingKey(msg.sender) {
-        require(initDisabled());
         require(_startTime > 0 && _endTime > 0);
         uint256 currentTime = getTime();
         require(_endTime > _startTime && _startTime > currentTime);

--- a/contracts/abstracts/VotingTo.sol
+++ b/contracts/abstracts/VotingTo.sol
@@ -138,6 +138,7 @@ contract VotingTo is EnumBallotTypes, EnumThresholdTypes, EternalStorage {
         uint8 _quorumState,
         address _creatorMiningKey
     ) internal returns(uint256) {
+        require(initDisabled());
         uint256 ballotId = nextBallotId();
         _setStartTime(ballotId, _startTime);
         _setEndTime(ballotId, _endTime);

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -100,6 +100,7 @@ module.exports = function(deployer, network, accounts) {
       );
       votingToChangeKeys = VotingToChangeKeys.at(votingToChangeKeys.address);
       await votingToChangeKeys.init(minBallotDuration);
+      await votingToChangeKeys.migrateDisable();
 
       // Deploy VotingToChangeMinThreshold
       votingToChangeMinThreshold = await VotingToChangeMinThreshold.new();
@@ -112,6 +113,7 @@ module.exports = function(deployer, network, accounts) {
         votingToChangeMinThreshold.address
       );
       await votingToChangeMinThreshold.init(minBallotDuration, demoMode ? 1 : 3);
+      await votingToChangeMinThreshold.migrateDisable();
 
       // Deploy VotingToChangeProxyAddress
       votingToChangeProxyAddress = await VotingToChangeProxyAddress.new();
@@ -124,6 +126,7 @@ module.exports = function(deployer, network, accounts) {
         votingToChangeProxyAddress.address
       );
       await votingToChangeProxyAddress.init(minBallotDuration);
+      await votingToChangeProxyAddress.migrateDisable();
 
       // Deploy VotingToManageEmissionFunds
       votingToManageEmissionFunds = await VotingToManageEmissionFunds.new();

--- a/scripts/migrate/migrateVotings.js
+++ b/scripts/migrate/migrateVotings.js
@@ -233,6 +233,7 @@ async function votingToChangeMigrateAndCheck(sender, key, chainId, contractName)
 				init = await votingNewInstance.methods.init(172800);
 			}
 			await utils.call(init, sender, contractNewAddress, key, chainId);
+			(await votingNewInstance.methods.initDisabled().call()).should.be.equal(true);
 		}
 
 		if (!ONLY_CHECK) {
@@ -312,6 +313,7 @@ async function votingToChangeMigrateAndCheck(sender, key, chainId, contractName)
 
 			console.log('  Disable migrations feature of the new contract...');
 			await utils.call(votingNewInstance.methods.migrateDisable(), sender, contractNewAddress, key, chainId);
+			(await votingNewInstance.methods.migrateDisabled().call()).should.be.equal(true);
 		}
 
 		if (ONLY_CHECK) {

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -69,6 +69,7 @@ contract('Voting to change keys [all features]', function (accounts) {
 
     voting = await VotingToChangeKeysMock.at(votingEternalStorage.address);
     await voting.init(172800).should.be.fulfilled;
+    await voting.migrateDisable().should.be.fulfilled;
   })
 
   describe('#createBallot', async () => {
@@ -985,6 +986,7 @@ contract('Voting to change keys [all features]', function (accounts) {
       let votingNew = await VotingToChangeKeysMock.new();
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
       votingNew = await VotingToChangeKeysMock.at(votingEternalStorage.address);
+      await votingNew.init(172800).should.be.fulfilled;
 
       let ballotInfo = await voting.getBallotInfo.call(id);
 
@@ -1056,6 +1058,7 @@ contract('Voting to change keys [all features]', function (accounts) {
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageStubAddress, voting.address);
       voting = await VotingToChangeKeysMock.at(votingEternalStorage.address);
       await voting.init(172800).should.be.fulfilled;
+      await voting.migrateDisable().should.be.fulfilled;
     });
     it('may only be called by ProxyStorage', async () => {
       let votingNew = await VotingToChangeKeysNew.new();

--- a/test/voting_to_change_keys_upgrade_test.js
+++ b/test/voting_to_change_keys_upgrade_test.js
@@ -46,15 +46,13 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
 
     let ballotsStorage = await BallotsStorage.new();
     const ballotsEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, ballotsStorage.address);
-    ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);
 
     const validatorMetadata = await ValidatorMetadata.new();
     const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
 
     voting = await VotingToChangeKeysMock.new();
     votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, voting.address);
-    voting = await VotingToChangeKeysMock.at(votingEternalStorage.address);
-    
+
     await proxyStorageMock.initializeAddresses(
       keysManagerEternalStorage.address,
       votingEternalStorage.address,
@@ -66,8 +64,12 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       accounts[0]
     );
 
+    ballotsStorage = await BallotsStorage.at(ballotsEternalStorage.address);
     await ballotsStorage.init([3, 2]).should.be.fulfilled;
+
+    voting = await VotingToChangeKeysMock.at(votingEternalStorage.address);
     await voting.init(172800).should.be.fulfilled;
+    await voting.migrateDisable().should.be.fulfilled;
 
     let votingNew = await VotingToChangeKeysNew.new();
     await votingEternalStorage.setProxyStorage(accounts[6]);
@@ -991,6 +993,7 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       let votingNew = await VotingToChangeKeysMock.new();
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
       votingNew = await VotingToChangeKeysMock.at(votingEternalStorage.address);
+      await votingNew.init(172800).should.be.fulfilled;
 
       let ballotInfo = await voting.getBallotInfo.call(id);
 

--- a/test/voting_to_change_min_threshold_test.js
+++ b/test/voting_to_change_min_threshold_test.js
@@ -59,6 +59,7 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
     voting = await Voting.at(votingEternalStorage.address);
     await voting.init(172800, 0).should.be.rejectedWith(ERROR_MSG);
     await voting.init(172800, 3).should.be.fulfilled;
+    await voting.migrateDisable().should.be.fulfilled;
     
     await proxyStorageMock.initializeAddresses(
       keysManager.address,
@@ -334,6 +335,7 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
       const votingForKeysEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingForKeys.address);
       votingForKeys = await VotingForKeys.at(votingForKeysEternalStorage.address);
       await votingForKeys.init(172800);
+      await votingForKeys.migrateDisable();
 
       const nextId = await votingForKeys.nextBallotId.call();
       await votingForKeys.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[1], 1, "memo", {from: votingKey});
@@ -503,6 +505,7 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
       let votingNew = await Voting.new();
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
       votingNew = await Voting.at(votingEternalStorage.address);
+      await votingNew.init(172800, 3).should.be.fulfilled;
 
       let ballotInfo = await voting.getBallotInfo.call(id, votingKey);
 
@@ -567,6 +570,7 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageStubAddress, voting.address);
       voting = await Voting.at(votingEternalStorage.address);
       await voting.init(172800, 3).should.be.fulfilled;
+      await voting.migrateDisable().should.be.fulfilled;
     });
     it('may only be called by ProxyStorage', async () => {
       let votingNew = await VotingNew.new();

--- a/test/voting_to_change_min_threshold_upgrade_test.js
+++ b/test/voting_to_change_min_threshold_upgrade_test.js
@@ -59,6 +59,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
     voting = await Voting.at(votingEternalStorage.address);
     await voting.init(172800, 0).should.be.rejectedWith(ERROR_MSG);
     await voting.init(172800, 3).should.be.fulfilled;
+    await voting.migrateDisable().should.be.fulfilled;
 
     const votingNew = await VotingNew.new();
     await votingEternalStorage.setProxyStorage(accounts[6]);
@@ -341,6 +342,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       const votingForKeysEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingForKeys.address);
       votingForKeys = await VotingForKeys.at(votingForKeysEternalStorage.address);
       await votingForKeys.init(172800);
+      await votingForKeys.migrateDisable();
 
       const nextId = await votingForKeys.nextBallotId.call();
       await votingForKeys.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[1], 1, "memo", {from: votingKey});
@@ -510,6 +512,7 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       let votingNew = await Voting.new();
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
       votingNew = await Voting.at(votingEternalStorage.address);
+      await votingNew.init(172800, 3).should.be.fulfilled;
 
       let ballotInfo = await voting.getBallotInfo.call(id, votingKey);
 

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -74,6 +74,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
     voting = await VotingToChangeProxyAddress.at(votingEternalStorage.address);
     await voting.init(172800, {from: accounts[8]}).should.be.rejectedWith(ERROR_MSG);
     await voting.init(172800).should.be.fulfilled;
+    await voting.migrateDisable().should.be.fulfilled;
 
     const validatorMetadata = await ValidatorMetadata.new();
     const validatorMetadataEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, validatorMetadata.address);
@@ -574,6 +575,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       let votingNew = await VotingToChangeProxyAddress.new();
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
       votingNew = await VotingToChangeProxyAddress.at(votingEternalStorage.address);
+      await votingNew.init(172800).should.be.fulfilled;
 
       let ballotInfo = await voting.getBallotInfo.call(id, votingKey);
 
@@ -640,6 +642,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageStubAddress, voting.address);
       voting = await VotingToChangeProxyAddress.at(votingEternalStorage.address);
       await voting.init(172800).should.be.fulfilled;
+      await voting.migrateDisable().should.be.fulfilled;
     });
     it('may only be called by ProxyStorage', async () => {
       let votingNew = await VotingToChangeProxyAddressNew.new();

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -74,6 +74,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
     voting = await VotingToChangeProxyAddress.at(votingEternalStorage.address);
     await voting.init(172800, {from: accounts[8]}).should.be.rejectedWith(ERROR_MSG);
     await voting.init(172800).should.be.fulfilled;
+    await voting.migrateDisable().should.be.fulfilled;
 
     votingNew = await VotingToChangeProxyAddressNew.new();
     await votingEternalStorage.setProxyStorage(accounts[7]);
@@ -581,6 +582,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       let votingNew = await VotingToChangeProxyAddress.new();
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageMock.address, votingNew.address);
       votingNew = await VotingToChangeProxyAddress.at(votingEternalStorage.address);
+      await votingNew.init(172800).should.be.fulfilled;
 
       let ballotInfo = await voting.getBallotInfo.call(id, votingKey);
 


### PR DESCRIPTION
- (Mandatory) Description
Now voting and finalization functions of `VotingToChange*` contracts cannot be called until `migrateDisable` function is called.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)