### PR TITLE
(Fix) Replace uint8 with uint256 to reduce gas spending

### DIFF
--- a/contracts/BallotsStorage.sol
+++ b/contracts/BallotsStorage.sol
@@ -20,7 +20,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
 
     bytes32 internal constant BALLOT_THRESHOLDS = "ballotThresholds";
 
-    event ThresholdChanged(uint8 indexed thresholdType, uint256 newValue);
+    event ThresholdChanged(uint256 indexed thresholdType, uint256 newValue);
 
     modifier onlyOwner() {
         require(msg.sender == addressStorage[OWNER]);
@@ -80,9 +80,9 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
     ) public onlyOwner {
         require(!initDisabled());
         require(_thresholds.length == uint256(ThresholdTypes.MetadataChange));
-        require(_thresholds.length < 255);
-        for (uint8 thresholdType = uint8(ThresholdTypes.Keys); thresholdType <= _thresholds.length; thresholdType++) {
-            uint256 thresholdValue = _thresholds[thresholdType - uint8(ThresholdTypes.Keys)];
+        //require(_thresholds.length < 255);
+        for (uint256 thresholdType = uint256(ThresholdTypes.Keys); thresholdType <= _thresholds.length; thresholdType++) {
+            uint256 thresholdValue = _thresholds[thresholdType - uint256(ThresholdTypes.Keys)];
             if (!_setThreshold(thresholdValue, thresholdType)) {
                 revert();
             }
@@ -99,7 +99,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         require(!initDisabled());
         uint8 thresholdKeysType = uint8(ThresholdTypes.Keys);
         uint8 thresholdMetadataType = uint8(ThresholdTypes.MetadataChange);
-        IBallotsStorage prevBallotsStorage = IBallotsStorage(_prevBallotsStorage);
+        IBallotsStoragePrev prevBallotsStorage = IBallotsStoragePrev(_prevBallotsStorage);
         if (!_setThreshold(prevBallotsStorage.getBallotThreshold(thresholdKeysType), thresholdKeysType)) {
             revert();
         }
@@ -109,7 +109,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         _initDisable();
     }
 
-    function setThreshold(uint256 _newValue, uint8 _thresholdType)
+    function setThreshold(uint256 _newValue, uint256 _thresholdType)
         public
         onlyVotingToChangeThreshold
         returns(bool)
@@ -120,7 +120,7 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         return true;
     }
 
-    function getBallotThreshold(uint8 _ballotType) public view returns(uint256) {
+    function getBallotThreshold(uint256 _ballotType) public view returns(uint256) {
         return uintStorage[keccak256(abi.encode(BALLOT_THRESHOLDS, _ballotType))];
     }
 
@@ -231,11 +231,11 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
         return poa.getCurrentValidatorsLengthWithoutMoC();
     }
 
-    function _setThreshold(uint256 _newValue, uint8 _thresholdType) internal returns(bool) {
+    function _setThreshold(uint256 _newValue, uint256 _thresholdType) internal returns(bool) {
         if (_newValue == 0) return false;
-        if (_thresholdType == uint8(ThresholdTypes.Invalid)) return false;
-        if (_thresholdType > uint8(ThresholdTypes.MetadataChange)) return false;
-        if (_thresholdType == uint8(ThresholdTypes.MetadataChange)) {
+        if (_thresholdType == uint256(ThresholdTypes.Invalid)) return false;
+        if (_thresholdType > uint256(ThresholdTypes.MetadataChange)) return false;
+        if (_thresholdType == uint256(ThresholdTypes.MetadataChange)) {
             if (_newValue > metadataChangeConfirmationsLimit()) {
                 return false;
             }

--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -69,7 +69,7 @@ contract KeysManager is EternalStorage, IKeysManager {
     }
 
     modifier onlyValidInitialKey() {
-        require(getInitialKeyStatus(msg.sender) == uint8(InitialKeyState.Activated));
+        require(getInitialKeyStatus(msg.sender) == uint256(InitialKeyState.Activated));
         _;
     }
 
@@ -87,9 +87,9 @@ contract KeysManager is EternalStorage, IKeysManager {
         }
         
         address currentKey = _currentKey;
-        uint8 maxDeep = maxOldMiningKeysDeepCheck();
+        uint256 maxDeep = maxOldMiningKeysDeepCheck();
         
-        for (uint8 i = 0; i < maxDeep; i++) {
+        for (uint256 i = 0; i < maxDeep; i++) {
             address oldMiningKey = getMiningKeyHistory(currentKey);
             if (oldMiningKey == address(0)) {
                 return false;
@@ -107,7 +107,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         return 2000;
     }
 
-    function maxOldMiningKeysDeepCheck() public pure returns(uint8) {
+    function maxOldMiningKeysDeepCheck() public pure returns(uint256) {
         return 25;
     }
 
@@ -135,10 +135,10 @@ contract KeysManager is EternalStorage, IKeysManager {
         return uintStorage[INITIAL_KEYS_COUNT];
     }
 
-    function getInitialKeyStatus(address _initialKey) public view returns(uint8) {
-        return uint8(uintStorage[
+    function getInitialKeyStatus(address _initialKey) public view returns(uint256) {
+        return uintStorage[
             keccak256(abi.encode(INITIAL_KEY_STATUS, _initialKey))
-        ]);
+        ];
     }
 
     function miningKeyByPayout(address _payoutKey) public view returns(address) {
@@ -225,8 +225,8 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setMiningKeyByPayout(payoutKey, _miningKey);
         _setSuccessfulValidatorClone(true, _miningKey);
         address currentMiningKey = _miningKey;
-        uint8 maxMiningKeyHistoryDeep = maxOldMiningKeysDeepCheck();
-        for (uint8 i = 0; i < maxMiningKeyHistoryDeep; i++) {
+        uint256 maxMiningKeyHistoryDeep = maxOldMiningKeysDeepCheck();
+        for (uint256 i = 0; i < maxMiningKeyHistoryDeep; i++) {
             address oldMiningKey = previous.getMiningKeyHistory(currentMiningKey);
             if (oldMiningKey == address(0)) {
                 break;
@@ -238,14 +238,14 @@ contract KeysManager is EternalStorage, IKeysManager {
     }
 
     function migrateInitialKey(address _initialKey) public onlyOwner {
-        require(getInitialKeyStatus(_initialKey) == uint8(InitialKeyState.Invalid));
+        require(getInitialKeyStatus(_initialKey) == uint256(InitialKeyState.Invalid));
         require(_initialKey != address(0));
         require(previousKeysManager() != address(0));
         IKeysManagerPrev previous = IKeysManagerPrev(previousKeysManager());
-        uint8 status = previous.getInitialKey(_initialKey);
+        uint256 status = previous.getInitialKey(_initialKey);
         require(
-            status == uint8(InitialKeyState.Activated) ||
-            status == uint8(InitialKeyState.Deactivated)
+            status == uint256(InitialKeyState.Activated) ||
+            status == uint256(InitialKeyState.Deactivated)
         );
         _setInitialKeyStatus(_initialKey, status);
         emit Migrated("initialKey", _initialKey);
@@ -254,11 +254,11 @@ contract KeysManager is EternalStorage, IKeysManager {
     function initiateKeys(address _initialKey) public {
         require(msg.sender == masterOfCeremony());
         require(_initialKey != address(0));
-        require(getInitialKeyStatus(_initialKey) == uint8(InitialKeyState.Invalid));
+        require(getInitialKeyStatus(_initialKey) == uint256(InitialKeyState.Invalid));
         require(_initialKey != masterOfCeremony());
         uint256 _initialKeysCount = initialKeysCount();
         require(_initialKeysCount < maxNumberOfInitialKeys());
-        _setInitialKeyStatus(_initialKey, uint8(InitialKeyState.Activated));
+        _setInitialKeyStatus(_initialKey, uint256(InitialKeyState.Activated));
         _initialKeysCount = _initialKeysCount.add(1);
         _setInitialKeysCount(_initialKeysCount);
         emit InitialKeyCreated(_initialKey, getTime(), _initialKeysCount);
@@ -297,7 +297,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setIsPayoutActive(true, _miningKey);
         _setMiningKeyByVoting(_votingKey, _miningKey);
         _setMiningKeyByPayout(_payoutKey, _miningKey);
-        _setInitialKeyStatus(msg.sender, uint8(InitialKeyState.Deactivated));
+        _setInitialKeyStatus(msg.sender, uint256(InitialKeyState.Deactivated));
         emit ValidatorInitialized(_miningKey, _votingKey, _payoutKey);
     }
 
@@ -535,7 +535,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         uintStorage[INITIAL_KEYS_COUNT] = _count;
     }
 
-    function _setInitialKeyStatus(address _initialKey, uint8 _status) private {
+    function _setInitialKeyStatus(address _initialKey, uint256 _status) private {
         uintStorage[
             keccak256(abi.encode(INITIAL_KEY_STATUS, _initialKey))
         ] = _status;

--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -181,34 +181,34 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
         if (!initDisabled()) return false;
         if (_contractAddress == address(0)) return false;
         bool success = false;
-        if (_contractType == uint8(ContractTypes.KeysManager)) {
+        if (_contractType == uint256(ContractTypes.KeysManager)) {
             success = IEternalStorageProxy(
                 getKeysManager()
             ).upgradeTo(_contractAddress);
-        } else if (_contractType == uint8(ContractTypes.VotingToChangeKeys)) {
+        } else if (_contractType == uint256(ContractTypes.VotingToChangeKeys)) {
             success = IEternalStorageProxy(
                 getVotingToChangeKeys()
             ).upgradeTo(_contractAddress);
-        } else if (_contractType == uint8(ContractTypes.VotingToChangeMinThreshold)) {
+        } else if (_contractType == uint256(ContractTypes.VotingToChangeMinThreshold)) {
             success = IEternalStorageProxy(
                 getVotingToChangeMinThreshold()
             ).upgradeTo(_contractAddress);
-        } else if (_contractType == uint8(ContractTypes.VotingToChangeProxy)) {
+        } else if (_contractType == uint256(ContractTypes.VotingToChangeProxy)) {
             success = IEternalStorageProxy(
                 getVotingToChangeProxy()
             ).upgradeTo(_contractAddress);
-        } else if (_contractType == uint8(ContractTypes.BallotsStorage)) {
+        } else if (_contractType == uint256(ContractTypes.BallotsStorage)) {
             success = IEternalStorageProxy(
                 getBallotsStorage()
             ).upgradeTo(_contractAddress);
-        } else if (_contractType == uint8(ContractTypes.PoaConsensus)) {
+        } else if (_contractType == uint256(ContractTypes.PoaConsensus)) {
             _setPoaConsensus(_contractAddress);
             success = true;
-        } else if (_contractType == uint8(ContractTypes.ValidatorMetadata)) {
+        } else if (_contractType == uint256(ContractTypes.ValidatorMetadata)) {
             success = IEternalStorageProxy(
                 getValidatorMetadata()
             ).upgradeTo(_contractAddress);
-        } else if (_contractType == uint8(ContractTypes.ProxyStorage)) {
+        } else if (_contractType == uint256(ContractTypes.ProxyStorage)) {
             success = IEternalStorageProxy(this).upgradeTo(_contractAddress);
         }
         if (success) {

--- a/contracts/ValidatorMetadata.sol
+++ b/contracts/ValidatorMetadata.sol
@@ -248,9 +248,9 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     {
         IKeysManager keysManager = _getKeysManager();
         address historyVoterMiningKey = _voterMiningKey;
-        uint8 maxDeep = keysManager.maxOldMiningKeysDeepCheck();
+        uint256 maxDeep = keysManager.maxOldMiningKeysDeepCheck();
 
-        for (uint8 i = 0; i < maxDeep; i++) {
+        for (uint256 i = 0; i < maxDeep; i++) {
             if (_isValidatorAlreadyVoted(_miningKey, historyVoterMiningKey)) {
                 return true;
             }
@@ -303,7 +303,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
     }
 
     function getMinThreshold() public view returns(uint256) {
-        return _getBallotsStorage().getBallotThreshold(uint8(ThresholdTypes.MetadataChange));
+        return _getBallotsStorage().getBallotThreshold(uint256(ThresholdTypes.MetadataChange));
     }
 
     function _storeName(bool _pending) private pure returns(string) {

--- a/contracts/VotingToChangeMinThreshold.sol
+++ b/contracts/VotingToChangeMinThreshold.sol
@@ -114,7 +114,7 @@ contract VotingToChangeMinThreshold is VotingToChange {
     function _finalizeBallotInner(uint256 _id) internal returns(bool) {
         return _getBallotsStorage().setThreshold(
             _getProposedValue(_id),
-            uint8(ThresholdTypes.Keys)
+            uint256(ThresholdTypes.Keys)
         );
     }
 

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -13,7 +13,7 @@ contract VotingToChangeProxyAddress is VotingToChange {
         uint256 _startTime,
         uint256 _endTime,
         address _proposedValue,
-        uint8 _contractType,
+        uint256 _contractType,
         string _memo
     ) public {
         require(_proposedValue != address(0));

--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -89,7 +89,7 @@ contract VotingToManageEmissionFunds is VotingTo {
             _startTime,
             _endTime,
             _memo,
-            uint8(QuorumStates.InProgress),
+            uint256(QuorumStates.InProgress),
             _getKeysManager().getMiningKeyByVoting(msg.sender)
         );
         _setSendVotes(ballotId, 0);
@@ -195,7 +195,7 @@ contract VotingToManageEmissionFunds is VotingTo {
         return releaseTime;
     }
 
-    function vote(uint256 _id, uint8 _choice) public onlyValidVotingKey(msg.sender) {
+    function vote(uint256 _id, uint256 _choice) public onlyValidVotingKey(msg.sender) {
         require(!_getIsCanceled(_id));
         require(!_getIsFinalized(_id));
         require(isValidVote(_id, msg.sender));
@@ -237,7 +237,7 @@ contract VotingToManageEmissionFunds is VotingTo {
         emit BallotFinalized(_id, msg.sender);
         
         if (getTotalVoters(_id) < getMinThresholdOfVoters(_id)) {
-            _setQuorumState(_id, uint8(QuorumStates.Frozen));
+            _setQuorumState(_id, uint256(QuorumStates.Frozen));
             _emissionFunds.freezeFunds(amount);
             return;
         }
@@ -269,7 +269,7 @@ contract VotingToManageEmissionFunds is VotingTo {
             }
         }
 
-        _setQuorumState(_id, uint8(quorumState));
+        _setQuorumState(_id, uint256(quorumState));
 
         if (quorumState == QuorumStates.Sent) {
             _emissionFunds.sendFundsTo(_getReceiver(_id), amount);

--- a/contracts/abstracts/VotingTo.sol
+++ b/contracts/abstracts/VotingTo.sol
@@ -63,8 +63,8 @@ contract VotingTo is EternalStorage, EnumBallotTypes, EnumThresholdTypes {
     {
         address miningKey = _miningKey;
         IKeysManager keysManager = _getKeysManager();
-        uint8 maxDeep = keysManager.maxOldMiningKeysDeepCheck();
-        for (uint8 i = 0; i < maxDeep; i++) {
+        uint256 maxDeep = keysManager.maxOldMiningKeysDeepCheck();
+        for (uint256 i = 0; i < maxDeep; i++) {
             address oldMiningKey = keysManager.getMiningKeyHistory(miningKey);
             if (oldMiningKey == address(0)) {
                 return false;
@@ -84,10 +84,10 @@ contract VotingTo is EternalStorage, EnumBallotTypes, EnumThresholdTypes {
         ];
     }
 
-    function getQuorumState(uint256 _id) public view returns(uint8) {
-        return uint8(uintStorage[
+    function getQuorumState(uint256 _id) public view returns(uint256) {
+        return uintStorage[
             keccak256(abi.encode(VOTING_STATE, _id, QUORUM_STATE))
-        ]);
+        ];
     }
 
     function getTime() public view returns(uint256) {
@@ -136,7 +136,7 @@ contract VotingTo is EternalStorage, EnumBallotTypes, EnumThresholdTypes {
         uint256 _startTime,
         uint256 _endTime,
         string _memo,
-        uint8 _quorumState,
+        uint256 _quorumState,
         address _creatorMiningKey
     ) internal returns(uint256) {
         require(initDisabled());
@@ -170,7 +170,7 @@ contract VotingTo is EternalStorage, EnumBallotTypes, EnumThresholdTypes {
     }
 
     function _getGlobalMinThresholdOfVoters() internal view returns(uint256) {
-        return _getBallotsStorage().getBallotThreshold(uint8(ThresholdTypes.Keys));
+        return _getBallotsStorage().getBallotThreshold(uint256(ThresholdTypes.Keys));
     }
 
     function _getIsFinalized(uint256 _id) internal view returns(bool) {
@@ -239,7 +239,7 @@ contract VotingTo is EternalStorage, EnumBallotTypes, EnumThresholdTypes {
         uintStorage[NEXT_BALLOT_ID] = _id;
     }
 
-    function _setQuorumState(uint256 _ballotId, uint8 _value) internal {
+    function _setQuorumState(uint256 _ballotId, uint256 _value) internal {
         uintStorage[
             keccak256(abi.encode(VOTING_STATE, _ballotId, QUORUM_STATE))
         ] = _value;

--- a/contracts/abstracts/VotingToChange.sol
+++ b/contracts/abstracts/VotingToChange.sol
@@ -106,7 +106,7 @@ contract VotingToChange is VotingTo {
         ];
     }
 
-    function vote(uint256 _id, uint8 _choice) public onlyValidVotingKey(msg.sender) {
+    function vote(uint256 _id, uint256 _choice) public onlyValidVotingKey(msg.sender) {
         require(migrateDisabled());
         require(!_getIsFinalized(_id));
         address miningKey = _getKeysManager().getMiningKeyByVoting(msg.sender);
@@ -186,7 +186,7 @@ contract VotingToChange is VotingTo {
             _startTime,
             _endTime,
             _memo,
-            uint8(QuorumStates.InProgress),
+            uint256(QuorumStates.InProgress),
             creatorMiningKey
         );
         _setTotalVoters(ballotId, 0);
@@ -225,12 +225,12 @@ contract VotingToChange is VotingTo {
 
         if (_getProgress(_id) > 0 && _getTotalVoters(_id) >= getMinThresholdOfVoters(_id)) {
             if (_finalizeBallotInner(_id)) {
-                _setQuorumState(_id, uint8(QuorumStates.Accepted));
+                _setQuorumState(_id, uint256(QuorumStates.Accepted));
             } else {
                 return;
             }
         } else {
-            _setQuorumState(_id, uint8(QuorumStates.Rejected));
+            _setQuorumState(_id, uint256(QuorumStates.Rejected));
         }
 
         _deactiveBallot(_id);

--- a/contracts/interfaces/IBallotsStorage.sol
+++ b/contracts/interfaces/IBallotsStorage.sol
@@ -2,12 +2,16 @@ pragma solidity ^0.4.24;
 
 
 interface IBallotsStorage {
-    function setThreshold(uint256, uint8) external returns(bool);
+    function setThreshold(uint256, uint256) external returns(bool);
     function areKeysBallotParamsValid(uint256, address, uint256, address) external view returns(bool);
-    function getBallotThreshold(uint8) external view returns(uint256);
+    function getBallotThreshold(uint256) external view returns(uint256);
     function getVotingToChangeThreshold() external view returns(address);
     function getProxyThreshold() external view returns(uint256);
     function getBallotLimitPerValidator() external view returns(uint256);
     function getMaxLimitBallot() external view returns(uint256);
     function metadataChangeConfirmationsLimit() external pure returns(uint256);
+}
+
+interface IBallotsStoragePrev {
+    function getBallotThreshold(uint8) external view returns(uint256);
 }

--- a/contracts/interfaces/IKeysManager.sol
+++ b/contracts/interfaces/IKeysManager.sol
@@ -25,9 +25,9 @@ interface IKeysManager {
     function getTime() external view returns(uint256);
     function getMiningKeyHistory(address) external view returns(address);
     function getMiningKeyByVoting(address) external view returns(address);
-    function getInitialKeyStatus(address) external view returns(uint8);
+    function getInitialKeyStatus(address) external view returns(uint256);
     function masterOfCeremony() external view returns(address);
-    function maxOldMiningKeysDeepCheck() external pure returns(uint8);
+    function maxOldMiningKeysDeepCheck() external pure returns(uint256);
     function miningKeyByPayout(address) external view returns(address);
     function miningKeyByVoting(address) external view returns(address);
 }

--- a/test/ballots_storage_upgrade_test.js
+++ b/test/ballots_storage_upgrade_test.js
@@ -73,7 +73,7 @@ contract('BallotsStorage upgraded [all features]', function (accounts) {
     await ballotsEternalStorage.setProxyStorage(proxyStorage.address);
     ballotsStorage = await BallotsStorageNew.at(ballotsEternalStorage.address);
   })
-
+  
   describe('#init', async () => {
     it('prevent from double init', async () => {
       await ballotsStorage.init([3, 2]).should.be.rejectedWith(ERROR_MSG);

--- a/test/mockContracts/BallotsStorageMock.sol
+++ b/test/mockContracts/BallotsStorageMock.sol
@@ -4,12 +4,15 @@ import '../../contracts/BallotsStorage.sol';
 
 
 contract BallotsStorageMock is BallotsStorage {
+	function getBallotThreshold(uint8 _ballotType) public view returns(uint256) {
+    	return uintStorage[keccak256(abi.encode(BALLOT_THRESHOLDS, _ballotType))];
+    }
+    
     function metadataChangeConfirmationsLimit() public pure returns(uint256) {
         return 2;
     }
 
-    function setThresholdMock(uint256 _newValue, uint8 _thresholdType) public {
+    function setThresholdMock(uint256 _newValue, uint256 _thresholdType) public {
         _setThreshold(_newValue, _thresholdType);
     }
-
 }

--- a/test/mockContracts/KeysManagerMock.sol
+++ b/test/mockContracts/KeysManagerMock.sol
@@ -5,7 +5,7 @@ import '../../contracts/KeysManager.sol';
 
 contract KeysManagerMock is KeysManager {
     function getInitialKey(address _initialKey) public view returns(uint8) {
-        return getInitialKeyStatus(_initialKey);
+        return uint8(getInitialKeyStatus(_initialKey));
     }
 
     function setProxyStorage(address _proxyStorage) public {

--- a/test/mockContracts/VotingToChangeKeysMock.sol
+++ b/test/mockContracts/VotingToChangeKeysMock.sol
@@ -58,7 +58,7 @@ contract VotingToChangeKeysMock is VotingToChangeMock, VotingToChangeKeys {
         totalVoters = _getTotalVoters(_id);
         progress = _getProgress(_id);
         isFinalized = _getIsFinalized(_id);
-        quorumState = getQuorumState(_id);
+        quorumState = uint8(getQuorumState(_id));
         ballotType = _getBallotType(_id);
         index = getIndex(_id);
         minThresholdOfVoters = getMinThresholdOfVoters(_id);

--- a/test/mockContracts/VotingToChangeMinThresholdMock.sol
+++ b/test/mockContracts/VotingToChangeMinThresholdMock.sol
@@ -44,7 +44,7 @@ contract VotingToChangeMinThresholdMock is VotingToChangeMock, VotingToChangeMin
         totalVoters = _getTotalVoters(_id);
         progress = _getProgress(_id);
         isFinalized = _getIsFinalized(_id);
-        quorumState = getQuorumState(_id);
+        quorumState = uint8(getQuorumState(_id));
         index = getIndex(_id);
         minThresholdOfVoters = getMinThresholdOfVoters(_id);
         proposedValue = _getProposedValue(_id);

--- a/test/mockContracts/VotingToChangeProxyAddressMock.sol
+++ b/test/mockContracts/VotingToChangeProxyAddressMock.sol
@@ -45,7 +45,7 @@ contract VotingToChangeProxyAddressMock is VotingToChangeMock, VotingToChangePro
         totalVoters = _getTotalVoters(_id);
         progress = _getProgress(_id);
         isFinalized = _getIsFinalized(_id);
-        quorumState = getQuorumState(_id);
+        quorumState = uint8(getQuorumState(_id));
         index = getIndex(_id);
         minThresholdOfVoters = getMinThresholdOfVoters(_id);
         proposedValue = _getProposedValue(_id);

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -110,7 +110,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       // uint256 _startTime,
       // uint256 _endTime,
       // address _proposedValue,
-      // uint8 _contractType
+      // uint256 _contractType
       const {logs} = await voting.createBallot(
         VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }
       );
@@ -499,7 +499,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
         accounts[7],       // address _proposedValue
-        100,               // uint8 _contractType
+        100,               // uint256 _contractType
         "memo",            // string _memo
         {from: votingKey}
       ).should.be.fulfilled;
@@ -532,7 +532,7 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
         accounts[8],       // address _proposedValue
-        100,               // uint8 _contractType
+        100,               // uint256 _contractType
         "memo",            // string _memo
         {from: votingKey}
       ).should.be.fulfilled;

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -117,7 +117,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       // uint256 _startTime,
       // uint256 _endTime,
       // address _proposedValue,
-      // uint8 _contractType
+      // uint256 _contractType
       const {logs} = await voting.createBallot(
         VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }
       );
@@ -506,7 +506,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
         accounts[7],       // address _proposedValue
-        100,               // uint8 _contractType
+        100,               // uint256 _contractType
         "memo",            // string _memo
         {from: votingKey}
       ).should.be.fulfilled;
@@ -539,7 +539,7 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
         accounts[8],       // address _proposedValue
-        100,               // uint8 _contractType
+        100,               // uint256 _contractType
         "memo",            // string _memo
         {from: votingKey}
       ).should.be.fulfilled;


### PR DESCRIPTION
- (Mandatory) Description
The `uint8` variables were changed to `uint256` to reduce gas spending.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)