### PR TITLE
(Refactor) Remove `this` and other code improvements

### DIFF
--- a/contracts/BallotsStorage.sol
+++ b/contracts/BallotsStorage.sol
@@ -80,8 +80,8 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
     ) public onlyOwner {
         require(!initDisabled());
         require(_thresholds.length == uint256(ThresholdTypes.MetadataChange));
-        //require(_thresholds.length < 255);
-        for (uint256 thresholdType = uint256(ThresholdTypes.Keys); thresholdType <= _thresholds.length; thresholdType++) {
+        uint256 thresholdType = uint256(ThresholdTypes.Keys);
+        for (; thresholdType <= _thresholds.length; thresholdType++) {
             uint256 thresholdValue = _thresholds[thresholdType - uint256(ThresholdTypes.Keys)];
             if (!_setThreshold(thresholdValue, thresholdType)) {
                 revert();

--- a/contracts/EmissionFunds.sol
+++ b/contracts/EmissionFunds.sol
@@ -9,21 +9,18 @@ contract EmissionFunds is IEmissionFunds {
     event FundsSentTo(
         address indexed receiver,
         address caller,
-        address indexed callerOrigin,
         uint256 amount,
         bool indexed success
     );
     
     event FundsBurnt(
         address caller,
-        address indexed callerOrigin,
         uint256 amount,
         bool indexed success
     );
 
     event FundsFrozen(
         address caller,
-        address indexed callerOrigin,
         uint256 amount
     );
 
@@ -48,7 +45,7 @@ contract EmissionFunds is IEmissionFunds {
         // using `send` instead of `transfer` to avoid revert on failure
         bool success = _receiver.send(_amount);
         // solhint-disable avoid-tx-origin
-        emit FundsSentTo(_receiver, msg.sender, tx.origin, _amount, success);
+        emit FundsSentTo(_receiver, msg.sender, _amount, success);
         // solhint-enable avoid-tx-origin
         return success;
     }
@@ -61,7 +58,7 @@ contract EmissionFunds is IEmissionFunds {
         // using `send` instead of `transfer` to avoid revert on failure
         bool success = address(0).send(_amount);
         // solhint-disable avoid-tx-origin
-        emit FundsBurnt(msg.sender, tx.origin, _amount, success);
+        emit FundsBurnt(msg.sender, _amount, success);
         // solhint-enable avoid-tx-origin
         return success;
     }
@@ -71,7 +68,7 @@ contract EmissionFunds is IEmissionFunds {
         onlyVotingToManageEmissionFunds
     {
         // solhint-disable avoid-tx-origin
-        emit FundsFrozen(msg.sender, tx.origin, _amount);
+        emit FundsFrozen(msg.sender, _amount);
         // solhint-enable avoid-tx-origin
     }
 }

--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -166,17 +166,17 @@ contract KeysManager is EternalStorage, IKeysManager {
     }
 
     function validatorKeys(address _miningKey) public view returns(
-        address votingKey,
-        address payoutKey,
-        bool isMiningActive,
-        bool isVotingActive,
-        bool isPayoutActive
+        address validatorVotingKey,
+        address validatorPayoutKey,
+        bool isValidatorMiningActive,
+        bool isValidatorVotingActive,
+        bool isValidatorPayoutActive
     ) {
-        votingKey = this.getVotingByMining(_miningKey);
-        payoutKey = this.getPayoutByMining(_miningKey);
-        isMiningActive = this.isMiningActive(_miningKey);
-        isVotingActive = this.isVotingActiveByMiningKey(_miningKey);
-        isPayoutActive = this.isPayoutActive(_miningKey);
+        validatorVotingKey = getVotingByMining(_miningKey);
+        validatorPayoutKey = getPayoutByMining(_miningKey);
+        isValidatorMiningActive = isMiningActive(_miningKey);
+        isValidatorVotingActive = isVotingActiveByMiningKey(_miningKey);
+        isValidatorPayoutActive = isPayoutActive(_miningKey);
     }
 
     function initDisabled() public view returns(bool) {

--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.4.24;
 import "./interfaces/IRewardByBlock.sol";
 import "./interfaces/IKeysManager.sol";
 import "./interfaces/IProxyStorage.sol";
-import "./interfaces/IPoaNetworkConsensus.sol";
 import "./eternal-storage/EternalStorage.sol";
 import "./libs/SafeMath.sol";
 

--- a/contracts/ValidatorMetadata.sol
+++ b/contracts/ValidatorMetadata.sol
@@ -525,6 +525,7 @@ contract ValidatorMetadata is EternalStorage, EnumThresholdTypes, IValidatorMeta
         address _miningKey,
         string _fullAddress
     ) private {
+        require(bytes(_fullAddress).length <= 200);
         stringStorage[keccak256(abi.encode(
             _storeName(_pending),
             _miningKey,

--- a/contracts/VotingToChangeMinThreshold.sol
+++ b/contracts/VotingToChangeMinThreshold.sol
@@ -37,7 +37,7 @@ contract VotingToChangeMinThreshold is VotingToChange {
         address creator,
         string memo,
         bool canBeFinalizedNow,
-        bool hasAlreadyVoted
+        bool alreadyVoted
     ) {
         startTime = _getStartTime(_id);
         endTime = _getEndTime(_id);
@@ -48,7 +48,7 @@ contract VotingToChangeMinThreshold is VotingToChange {
         creator = _getCreator(_id);
         memo = _getMemo(_id);
         canBeFinalizedNow = _canBeFinalizedNow(_id);
-        hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
+        alreadyVoted = hasAlreadyVoted(_id, _votingKey);
     }
 
     function init(

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -38,7 +38,7 @@ contract VotingToChangeProxyAddress is VotingToChange {
         address creator,
         string memo,
         bool canBeFinalizedNow,
-        bool hasAlreadyVoted
+        bool alreadyVoted
     ) {
         startTime = _getStartTime(_id);
         endTime = _getEndTime(_id);
@@ -50,7 +50,7 @@ contract VotingToChangeProxyAddress is VotingToChange {
         creator = _getCreator(_id);
         memo = _getMemo(_id);
         canBeFinalizedNow = _canBeFinalizedNow(_id);
-        hasAlreadyVoted = this.hasAlreadyVoted(_id, _votingKey);
+        alreadyVoted = hasAlreadyVoted(_id, _votingKey);
     }
 
     function migrateBasicOne(

--- a/contracts/interfaces/IBallotsStorage.sol
+++ b/contracts/interfaces/IBallotsStorage.sol
@@ -12,6 +12,7 @@ interface IBallotsStorage {
     function metadataChangeConfirmationsLimit() external pure returns(uint256);
 }
 
+
 interface IBallotsStoragePrev {
     function getBallotThreshold(uint8) external view returns(uint256);
 }

--- a/scripts/migrate/migrateAll.js
+++ b/scripts/migrate/migrateAll.js
@@ -226,7 +226,7 @@ async function main() {
 			await votingToManageEmissionFundsInstance.methods.initDisabled().call()
 		);
 		true.should.be.equal(
-			await votingToManageEmissionFundsInstance.methods.previousBallotFinalized().call()
+			await votingToManageEmissionFundsInstance.methods.noActiveBallotExists().call()
 		);
 		EthereumUtil.toChecksumAddress(votingToManageEmissionFundsAddress).should.be.equal(
 			EthereumUtil.toChecksumAddress(await emissionFundsInstance.methods.votingToManageEmissionFunds().call())

--- a/scripts/migrate/migrateKeys.js
+++ b/scripts/migrate/migrateKeys.js
@@ -174,9 +174,16 @@ async function migrateAndCheck(privateKey) {
 			console.log(`  Check mining key ${miningKey}...`);
 			
 			try {
-				(await keysManagerOldInstance.methods.validatorKeys(miningKey).call()).should.be.deep.equal(
-					await keysManagerNewInstance.methods.validatorKeys(miningKey).call()
-				);
+				const validatorOldKeys = await keysManagerOldInstance.methods.validatorKeys(miningKey).call();
+				const validatorNewKeys = await keysManagerNewInstance.methods.validatorKeys(miningKey).call();
+				validatorOldKeys[0].should.be.equal(validatorNewKeys[0]);
+				validatorOldKeys[1].should.be.equal(validatorNewKeys[1]);
+				validatorOldKeys[2].should.be.equal(validatorNewKeys[2]);
+				validatorOldKeys[3].should.be.equal(validatorNewKeys[3]);
+				validatorOldKeys[4].should.be.equal(validatorNewKeys[4]);
+				//(await keysManagerOldInstance.methods.validatorKeys(miningKey).call()).should.be.deep.equal(
+				//	await keysManagerNewInstance.methods.validatorKeys(miningKey).call()
+				//);
 				const votingKey = await keysManagerOldInstance.methods.getVotingByMining(miningKey).call();
 				votingKey.should.be.equal(
 					await keysManagerNewInstance.methods.getVotingByMining(miningKey).call()

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -107,6 +107,13 @@ contract('ValidatorMetadata [all features]', function (accounts) {
       logs[0].event.should.be.equal('MetadataCreated');
       logs[0].args.miningKey.should.be.equal(miningKey);
     })
+    it('should not let create metadata if fullAddress is too long', async () => {
+      let localFakeData = fakeData.slice();
+      localFakeData[3] = 'a'.repeat(201);
+      await metadata.createMetadata(...localFakeData, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      localFakeData[3] = 'a'.repeat(200);
+      await metadata.createMetadata(...localFakeData, {from: votingKey}).should.be.fulfilled;
+    });
     it('should not let create metadata if called by non-voting key', async () => {
       const {logs} = await metadata.createMetadata(...fakeData, {from: miningKey}).should.be.rejectedWith(ERROR_MSG);
       const validators = await metadata.validators.call(miningKey);

--- a/test/metadata_upgrade_test.js
+++ b/test/metadata_upgrade_test.js
@@ -114,6 +114,13 @@ contract('ValidatorMetadata upgraded [all features]', function (accounts) {
       logs[0].event.should.be.equal('MetadataCreated');
       logs[0].args.miningKey.should.be.equal(miningKey);
     })
+    it('should not let create metadata if fullAddress is too long', async () => {
+      let localFakeData = fakeData.slice();
+      localFakeData[3] = 'a'.repeat(201);
+      await metadata.createMetadata(...localFakeData, {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      localFakeData[3] = 'a'.repeat(200);
+      await metadata.createMetadata(...localFakeData, {from: votingKey}).should.be.fulfilled;
+    });
     it('should not let create metadata if called by non-voting key', async () => {
       const {logs} = await metadata.createMetadata(...fakeData, {from: miningKey}).should.be.rejectedWith(ERROR_MSG);
       const validators = await metadata.validators.call(miningKey);

--- a/test/voting_to_manage_emission_funds_test.js
+++ b/test/voting_to_manage_emission_funds_test.js
@@ -150,7 +150,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       (await voting.emissionFunds.call()).should.be.equal(emissionFunds.address);
       (await voting.emissionReleaseThreshold.call()).should.be.bignumber.equal(emissionReleaseThreshold);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(emissionReleaseTime);
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.initDisabled.call()).should.be.equal(true);
       (await voting.proxyStorage.call()).should.be.equal(proxyStorage.address);
       (await voting.getKeysManager.call()).should.be.equal(keysManager.address);
@@ -202,7 +202,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       (await voting.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(2);
       (await voting.getEmissionReleaseTimeSnapshot.call(id)).should.be.bignumber.equal(emissionReleaseTime);
 
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
       (await voting.nextBallotId.call()).should.be.bignumber.equal(1);
       logs[0].event.should.be.equal("BallotCreated");
       logs[0].args.id.should.be.bignumber.equal(0);
@@ -356,7 +356,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
         new web3.BigNumber(0), // sendVotes
         accounts[5] // receiver
       ]);
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(emissionReleaseTime);
 
       id = await voting.nextBallotId.call();
@@ -368,7 +368,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
 
       await voting.setTime(VOTING_START_DATE);
       await voting.vote(id, choice.freeze, {from: votingKey}).should.be.fulfilled;
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
 
       await voting.setTime(VOTING_END_DATE + 1);
       await voting.finalize(id, {from: votingKey}).should.be.fulfilled;
@@ -537,7 +537,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       ballotInfo[8].should.be.bignumber.equal(0); // burnVotes
       ballotInfo[9].should.be.bignumber.equal(1); // freezeVotes
       ballotInfo[10].should.be.bignumber.equal(0); // sendVotes
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.getQuorumState.call(id)).should.be.bignumber.equal(4);
       (await voting.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(1);
       (await voting.hasAlreadyVoted.call(id, votingKey)).should.be.equal(true);
@@ -584,7 +584,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       (await voting.hasMiningKeyAlreadyVoted.call(id, miningKey)).should.be.equal(true);
       (await voting.hasMiningKeyAlreadyVoted.call(id, miningKey2)).should.be.equal(true);
       (await voting.hasMiningKeyAlreadyVoted.call(id, miningKey3)).should.be.equal(true);
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.getQuorumState.call(id)).should.be.bignumber.equal(3);
       (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(0);
     });
@@ -734,14 +734,14 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       ).should.be.fulfilled;
 
       false.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
 
       await addValidator(votingKey2, miningKey2);
       await voting.setTime(VOTING_END_DATE + 1);
       const {logs} = await voting.finalize(id, {from: votingKey2}).should.be.fulfilled;
 
       true.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(
         emissionReleaseTime + emissionReleaseThreshold
       );
@@ -919,7 +919,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       await voting.vote(id, choice.burn, {from: votingKey3}).should.be.fulfilled;
       true.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
       
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
     });
 
     it('does not finalize immediately until ballot canceling threshold is reached', async () => {
@@ -977,7 +977,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       ).should.be.fulfilled;
 
       false.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
 
       await addValidator(votingKey2, miningKey2);
       await voting.setTime(VOTING_END_DATE + 1);
@@ -988,7 +988,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       await voting.finalize(id, {from: votingKey}).should.be.fulfilled;
       true.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
 
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(
         emissionReleaseTime + emissionReleaseThreshold
       );
@@ -1111,7 +1111,7 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       ]);
       (await votingNew.getQuorumState.call(id)).should.be.bignumber.equal(1);
       (await votingNew.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(1);
-      (await votingNew.previousBallotFinalized.call()).should.be.equal(false);
+      (await votingNew.noActiveBallotExists.call()).should.be.equal(false);
       (await votingNew.nextBallotId.call()).should.be.bignumber.equal(1);
     });
   });

--- a/test/voting_to_manage_emission_funds_upgrade_test.js
+++ b/test/voting_to_manage_emission_funds_upgrade_test.js
@@ -157,7 +157,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       (await voting.emissionFunds.call()).should.be.equal(emissionFunds.address);
       (await voting.emissionReleaseThreshold.call()).should.be.bignumber.equal(emissionReleaseThreshold);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(emissionReleaseTime);
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.initDisabled.call()).should.be.equal(true);
       (await voting.proxyStorage.call()).should.be.equal(proxyStorage.address);
       (await voting.getKeysManager.call()).should.be.equal(keysManager.address);
@@ -209,7 +209,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       (await voting.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(2);
       (await voting.getEmissionReleaseTimeSnapshot.call(id)).should.be.bignumber.equal(emissionReleaseTime);
 
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
       (await voting.nextBallotId.call()).should.be.bignumber.equal(1);
       logs[0].event.should.be.equal("BallotCreated");
       logs[0].args.id.should.be.bignumber.equal(0);
@@ -363,7 +363,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
         new web3.BigNumber(0), // sendVotes
         accounts[5] // receiver
       ]);
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(emissionReleaseTime);
 
       id = await voting.nextBallotId.call();
@@ -375,7 +375,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
 
       await voting.setTime(VOTING_START_DATE);
       await voting.vote(id, choice.freeze, {from: votingKey}).should.be.fulfilled;
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
 
       await voting.setTime(VOTING_END_DATE + 1);
       await voting.finalize(id, {from: votingKey}).should.be.fulfilled;
@@ -544,7 +544,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       ballotInfo[8].should.be.bignumber.equal(0); // burnVotes
       ballotInfo[9].should.be.bignumber.equal(1); // freezeVotes
       ballotInfo[10].should.be.bignumber.equal(0); // sendVotes
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.getQuorumState.call(id)).should.be.bignumber.equal(4);
       (await voting.getMinThresholdOfVoters.call(id)).should.be.bignumber.equal(1);
       (await voting.hasAlreadyVoted.call(id, votingKey)).should.be.equal(true);
@@ -591,7 +591,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       (await voting.hasMiningKeyAlreadyVoted.call(id, miningKey)).should.be.equal(true);
       (await voting.hasMiningKeyAlreadyVoted.call(id, miningKey2)).should.be.equal(true);
       (await voting.hasMiningKeyAlreadyVoted.call(id, miningKey3)).should.be.equal(true);
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.getQuorumState.call(id)).should.be.bignumber.equal(3);
       (await web3.eth.getBalance(emissionFunds.address)).should.be.bignumber.equal(0);
     });
@@ -741,14 +741,14 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       ).should.be.fulfilled;
 
       false.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
 
       await addValidator(votingKey2, miningKey2);
       await voting.setTime(VOTING_END_DATE + 1);
       const {logs} = await voting.finalize(id, {from: votingKey2}).should.be.fulfilled;
 
       true.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(
         emissionReleaseTime + emissionReleaseThreshold
       );
@@ -926,7 +926,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       await voting.vote(id, choice.burn, {from: votingKey3}).should.be.fulfilled;
       true.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
       
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
     });
 
     it('does not finalize immediately until ballot canceling threshold is reached', async () => {
@@ -984,7 +984,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       ).should.be.fulfilled;
 
       false.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
-      (await voting.previousBallotFinalized.call()).should.be.equal(false);
+      (await voting.noActiveBallotExists.call()).should.be.equal(false);
 
       await addValidator(votingKey2, miningKey2);
       await voting.setTime(VOTING_END_DATE + 1);
@@ -995,7 +995,7 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
       await voting.finalize(id, {from: votingKey}).should.be.fulfilled;
       true.should.be.equal((await voting.getBallotInfo.call(id))[4]); // isFinalized
 
-      (await voting.previousBallotFinalized.call()).should.be.equal(true);
+      (await voting.noActiveBallotExists.call()).should.be.equal(true);
       (await voting.emissionReleaseTime.call()).should.be.bignumber.equal(
         emissionReleaseTime + emissionReleaseThreshold
       );


### PR DESCRIPTION
**(Mandatory) Description**

Changes made within this PR:
- `tx.origin` was removed from the events of `EmissionFunds` contract;
- `this.` notation was removed from `KeysManager` and `VotingToChange*` contracts;
- `fullAddress` in `ValidatorMetadata` was limited to 200 bytes max;
- `VotingToManageEmissionFunds.previousBallotFinalized` function was renamed to `noActiveBallotExists`.

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Refactor)