### PR TITLE
(Refactor) Put address arguments at the end of argument list of functions

### DIFF
--- a/contracts/BallotsStorage.sol
+++ b/contracts/BallotsStorage.sol
@@ -34,8 +34,8 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
 
     function areKeysBallotParamsValid(
         uint256 _ballotType,
-        address _affectedKey,
         uint256 _affectedKeyType,
+        address _affectedKey,
         address _miningKey
     ) external view returns(bool) {
         require(_ballotType >= uint256(BallotTypes.KeyAdding));
@@ -46,22 +46,22 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
 
         if (_ballotType == uint256(BallotTypes.KeyAdding)) {
             return _areKeyAddingBallotParamsValid(
-                _affectedKey,
                 _affectedKeyType, 
+                _affectedKey,
                 _miningKey
             );
         }
         if (_ballotType == uint256(BallotTypes.KeyRemoval)) {
             return _areKeyRemovalBallotParamsValid(
-                _affectedKey,
                 _affectedKeyType,
+                _affectedKey,
                 _miningKey
             );
         }
         if (_ballotType == uint256(BallotTypes.KeySwap)) {
             return _areKeySwapBallotParamsValid(
-                _affectedKey,
                 _affectedKeyType,
+                _affectedKey,
                 _miningKey
             );
         }
@@ -149,8 +149,8 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
     }
 
     function _areKeyAddingBallotParamsValid(
-        address _affectedKey,
         uint256 _affectedKeyType,
+        address _affectedKey,
         address _miningKey
     ) internal view returns(bool) {
         IKeysManager keysManager = _getKeysManager();
@@ -169,8 +169,8 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
     }
 
     function _areKeyRemovalBallotParamsValid(
-        address _affectedKey,
         uint256 _affectedKeyType,
+        address _affectedKey,
         address _miningKey
     ) internal view returns(bool) {
         IKeysManager keysManager = _getKeysManager();
@@ -193,8 +193,8 @@ contract BallotsStorage is EternalStorage, EnumBallotTypes, EnumKeyTypes, EnumTh
     }
 
     function _areKeySwapBallotParamsValid(
-        address _affectedKey,
         uint256 _affectedKeyType,
+        address _affectedKey,
         address _miningKey
     ) internal view returns(bool) {
         require(_affectedKey != _miningKey);

--- a/contracts/KeysManager.sol
+++ b/contracts/KeysManager.sol
@@ -78,6 +78,8 @@ contract KeysManager is EternalStorage, IKeysManager {
         view
         returns(bool)
     {
+        require(msg.data.length >= 32*2 + 4);
+
         if (isMiningActive(_newKey)) {
             return true;
         }
@@ -247,7 +249,7 @@ contract KeysManager is EternalStorage, IKeysManager {
             status == uint256(InitialKeyState.Activated) ||
             status == uint256(InitialKeyState.Deactivated)
         );
-        _setInitialKeyStatus(_initialKey, status);
+        _setInitialKeyStatus(status, _initialKey);
         emit Migrated("initialKey", _initialKey);
     }
 
@@ -258,7 +260,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         require(_initialKey != masterOfCeremony());
         uint256 _initialKeysCount = initialKeysCount();
         require(_initialKeysCount < maxNumberOfInitialKeys());
-        _setInitialKeyStatus(_initialKey, uint256(InitialKeyState.Activated));
+        _setInitialKeyStatus(uint256(InitialKeyState.Activated), _initialKey);
         _initialKeysCount = _initialKeysCount.add(1);
         _setInitialKeysCount(_initialKeysCount);
         emit InitialKeyCreated(_initialKey, getTime(), _initialKeysCount);
@@ -297,7 +299,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         _setIsPayoutActive(true, _miningKey);
         _setMiningKeyByVoting(_votingKey, _miningKey);
         _setMiningKeyByPayout(_payoutKey, _miningKey);
-        _setInitialKeyStatus(msg.sender, uint256(InitialKeyState.Deactivated));
+        _setInitialKeyStatus(uint256(InitialKeyState.Deactivated), msg.sender);
         emit ValidatorInitialized(_miningKey, _votingKey, _payoutKey);
     }
 
@@ -535,7 +537,7 @@ contract KeysManager is EternalStorage, IKeysManager {
         uintStorage[INITIAL_KEYS_COUNT] = _count;
     }
 
-    function _setInitialKeyStatus(address _initialKey, uint256 _status) private {
+    function _setInitialKeyStatus(uint256 _status, address _initialKey) private {
         uintStorage[
             keccak256(abi.encode(INITIAL_KEY_STATUS, _initialKey))
         ] = _status;

--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -140,7 +140,7 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
         address _validatorMetadataEternalStorage,
         address _rewardByBlockEternalStorage
     ) public {
-        require(isValidator(msg.sender) || _isOwner(msg.sender));
+        require(_isOwner(msg.sender) || _isMoC(msg.sender));
         require(!mocInitialized());
         addressStorage[KEYS_MANAGER_ETERNAL_STORAGE] =
             _keysManagerEternalStorage;
@@ -218,9 +218,10 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
     }
     // solhint-enable code-complexity
 
-    function isValidator(address _validator) public view returns(bool) {
+    function _isMoC(address _validator) public view returns(bool) {
         IPoaNetworkConsensus poa = IPoaNetworkConsensus(getPoaConsensus());
-        return poa.isValidator(_validator);
+        return _validator == poa.masterOfCeremony() && !poa.isMasterOfCeremonyRemoved();
+        //return poa.isValidator(_validator);
     }
 
     function _isOwner(address _sender) private view returns(bool) {

--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -22,7 +22,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
     address public constant bridgeContract = 0x0000000000000000000000000000000000000000;
     // solhint-enable const-name-snakecase
 
-    event AddedReceiver(address indexed receiver, uint256 amount);
+    event AddedReceiver(uint256 amount, address indexed receiver);
     event Rewarded(address[] receivers, uint256[] rewards);
 
     modifier onlyBridgeContract {
@@ -35,16 +35,16 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
         _;
     }
 
-    function addExtraReceiver(address _receiver, uint256 _amount)
+    function addExtraReceiver(uint256 _amount, address _receiver)
         external
         onlyBridgeContract
     {
         require(_receiver != address(0));
         require(_amount != 0);
         require(extraReceiversAmounts(_receiver) == 0);
-        _setExtraReceiverAmount(_receiver, _amount);
+        _setExtraReceiverAmount(_amount, _receiver);
         _addExtraReceiver(_receiver);
-        emit AddedReceiver(_receiver, _amount);
+        emit AddedReceiver(_amount, _receiver);
     }
 
     function reward(address[] benefactors, uint16[] kind)
@@ -74,7 +74,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
             uint256 extraIndex = i.add(2);
             address extraAddress = extraReceivers(i);
             uint256 extraAmount = extraReceiversAmounts(extraAddress);
-            _setExtraReceiverAmount(extraAddress, 0);
+            _setExtraReceiverAmount(0, extraAddress);
             receivers[extraIndex] = extraAddress;
             rewards[extraIndex] = extraAmount;
         }
@@ -135,7 +135,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
         return keysManager.isMiningActive(_miningKey);
     }
 
-    function _setExtraReceiverAmount(address _receiver, uint256 _amount) private {
+    function _setExtraReceiverAmount(uint256 _amount, address _receiver) private {
         uintStorage[
             keccak256(abi.encode(EXTRA_RECEIVERS_AMOUNTS, _receiver))
         ] = _amount;

--- a/contracts/VotingToChangeKeys.sol
+++ b/contracts/VotingToChangeKeys.sol
@@ -17,19 +17,19 @@ contract VotingToChangeKeys is VotingToChange, EnumKeyTypes {
     function createBallot(
         uint256 _startTime,
         uint256 _endTime,
-        address _affectedKey,
-        uint256 _affectedKeyType,
-        address _miningKey,
         uint256 _ballotType,
-        string _memo
+        uint256 _affectedKeyType,
+        string _memo,
+        address _affectedKey,
+        address _miningKey
     ) public returns(uint256) {
         require(_getBallotsStorage().areKeysBallotParamsValid(
             _ballotType,
-            _affectedKey,
             _affectedKeyType,
+            _affectedKey,
             _miningKey
         ));
-        uint256 ballotId = _createBallot(_ballotType, _startTime, _endTime, _memo);
+        uint256 ballotId = super._createBallot(_ballotType, _startTime, _endTime, _memo);
         _setAffectedKey(ballotId, _affectedKey);
         _setAffectedKeyType(ballotId, _affectedKeyType);
         _setMiningKey(ballotId, _miningKey);
@@ -40,10 +40,10 @@ contract VotingToChangeKeys is VotingToChange, EnumKeyTypes {
     function createBallotToAddNewValidator(
         uint256 _startTime,
         uint256 _endTime,
+        string _memo,
         address _newMiningKey,
         address _newVotingKey,
-        address _newPayoutKey,
-        string _memo
+        address _newPayoutKey
     ) public returns(uint256) {
         IKeysManager keysManager = _getKeysManager();
         require(keysManager.miningKeyByVoting(_newVotingKey) == address(0));
@@ -56,11 +56,11 @@ contract VotingToChangeKeys is VotingToChange, EnumKeyTypes {
         uint256 ballotId = createBallot(
             _startTime,
             _endTime,
-            _newMiningKey, // _affectedKey
-            uint256(KeyTypes.MiningKey), // _affectedKeyType
-            address(0), // _miningKey
             uint256(BallotTypes.KeyAdding), // _ballotType
-            _memo
+            uint256(KeyTypes.MiningKey), // _affectedKeyType
+            _memo,
+            _newMiningKey, // _affectedKey
+            address(0) // _miningKey
         );
         _setNewVotingKey(ballotId, _newVotingKey);
         _setNewPayoutKey(ballotId, _newPayoutKey);

--- a/contracts/VotingToChangeMinThreshold.sol
+++ b/contracts/VotingToChangeMinThreshold.sol
@@ -18,7 +18,7 @@ contract VotingToChangeMinThreshold is VotingToChange {
         require(_proposedValue >= minPossibleThreshold());
         require(_proposedValue != _getGlobalMinThresholdOfVoters());
         require(_proposedValue <= _getBallotsStorage().getProxyThreshold());
-        uint256 ballotId = _createBallot(
+        uint256 ballotId = super._createBallot(
             uint256(BallotTypes.MinThreshold),
             _startTime,
             _endTime,

--- a/contracts/VotingToChangeProxyAddress.sol
+++ b/contracts/VotingToChangeProxyAddress.sol
@@ -12,12 +12,12 @@ contract VotingToChangeProxyAddress is VotingToChange {
     function createBallot(
         uint256 _startTime,
         uint256 _endTime,
-        address _proposedValue,
         uint256 _contractType,
-        string _memo
+        string _memo,
+        address _proposedValue
     ) public {
         require(_proposedValue != address(0));
-        uint256 ballotId = _createBallot(
+        uint256 ballotId = super._createBallot(
             uint256(BallotTypes.ProxyAddress),
             _startTime,
             _endTime,

--- a/contracts/VotingToManageEmissionFunds.sol
+++ b/contracts/VotingToManageEmissionFunds.sol
@@ -83,7 +83,7 @@ contract VotingToManageEmissionFunds is VotingTo {
         require(_endTime.sub(releaseTime) <= distributionThreshold());
         require(_receiver != address(0));
         require(noActiveBallotExists());
-        uint256 ballotId = _createBallot(
+        uint256 ballotId = super._createBallot(
             uint256(BallotTypes.ManageEmissionFunds),
             _startTime,
             _endTime,
@@ -156,17 +156,17 @@ contract VotingToManageEmissionFunds is VotingTo {
     }
 
     function init(
-        address _emissionFunds,
         uint256 _emissionReleaseTime, // unix timestamp
         uint256 _emissionReleaseThreshold, // seconds
-        uint256 _distributionThreshold // seconds
+        uint256 _distributionThreshold, // seconds
+        address _emissionFunds
     ) public onlyOwner {
         require(!initDisabled());
-        require(_emissionFunds != address(0));
         require(_emissionReleaseTime > getTime());
         require(_emissionReleaseThreshold > 0);
         require(_distributionThreshold > ballotCancelingThreshold());
         require(_emissionReleaseThreshold > _distributionThreshold);
+        require(_emissionFunds != address(0));
         _setNoActiveBallotExists(true);
         _setEmissionReleaseTime(_emissionReleaseTime);
         addressStorage[EMISSION_FUNDS] = _emissionFunds;

--- a/contracts/interfaces/IBallotsStorage.sol
+++ b/contracts/interfaces/IBallotsStorage.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 
 interface IBallotsStorage {
     function setThreshold(uint256, uint256) external returns(bool);
-    function areKeysBallotParamsValid(uint256, address, uint256, address) external view returns(bool);
+    function areKeysBallotParamsValid(uint256, uint256, address, address) external view returns(bool);
     function getBallotThreshold(uint256) external view returns(uint256);
     function getVotingToChangeThreshold() external view returns(address);
     function getProxyThreshold() external view returns(uint256);

--- a/contracts/interfaces/IProxyStorage.sol
+++ b/contracts/interfaces/IProxyStorage.sol
@@ -7,7 +7,6 @@ interface IProxyStorage {
     ) external;
 
     function setContractAddress(uint256, address) external returns(bool);
-    function isValidator(address) external view returns(bool);
     function getBallotsStorage() external view returns(address);
     function getKeysManager() external view returns(address);
     function getPoaConsensus() external view returns(address);

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -155,10 +155,10 @@ module.exports = function(deployer, network, accounts) {
 
       // Initialize VotingToManageEmissionFunds
       await votingToManageEmissionFunds.init(
-        emissionFunds.address,
         moment.utc().add(3, 'months').unix(),
         7776000,
-        604800
+        604800,
+        emissionFunds.address
       );
 
       // Initialize ProxyStorage

--- a/scripts/migrate/migrateAll.js
+++ b/scripts/migrate/migrateAll.js
@@ -200,14 +200,14 @@ async function main() {
 		console.log('');
 
 		console.log('VotingToManageEmissionFunds.init...');
-		const distributionThreshold = 604800; // seven days, in seconds
-		const emissionReleaseThreshold = 7776000; // three months, in seconds
-		const emissionReleaseTime = 1542412800 + emissionReleaseThreshold; // 2018-11-17 plus emissionReleaseThreshold (unix timestamp)
+		const distributionThreshold = 259200; // three days, in seconds
+		const emissionReleaseThreshold = 604800; // seven days, in seconds
+		const emissionReleaseTime = Math.floor(new Date() / 1000) + emissionReleaseThreshold; // now plus emissionReleaseThreshold (unix timestamp)
 		init = votingToManageEmissionFundsInstance.methods.init(
-			emissionFundsAddress,
 			emissionReleaseTime,
 			emissionReleaseThreshold,
-			distributionThreshold
+			distributionThreshold,
+			emissionFundsAddress
 		);
 		await utils.call(init, sender, votingToManageEmissionFundsAddress, key, chainId);
 		emissionFundsAddress.should.be.equal(

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -65,12 +65,9 @@ contract('ProxyStorage [all features]', function (accounts) {
     rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorage.address, rewardByBlock.address);
   })
   describe('#constructor', async () => {
-    it('sets MoC and Poa', async () => {
+    it('sets PoA', async () => {
       poaNetworkConsensus.address.should.be.equal(
         await proxyStorage.getPoaConsensus.call()
-      );
-      true.should.be.equal(
-        await proxyStorage.isValidator.call(masterOfCeremony)
       );
     })
   })

--- a/test/proxy_storage_upgrade_test.js
+++ b/test/proxy_storage_upgrade_test.js
@@ -72,12 +72,9 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
     rewardByBlockEternalStorage = await EternalStorageProxy.new(proxyStorage.address, rewardByBlock.address);
   })
   describe('#constructor', async () => {
-    it('sets MoC and Poa', async () => {
+    it('sets PoA', async () => {
       poaNetworkConsensus.address.should.be.equal(
         await proxyStorage.getPoaConsensus.call()
-      );
-      true.should.be.equal(
-        await proxyStorage.isValidator.call(masterOfCeremony)
       );
     })
   })

--- a/test/reward_by_block_test.js
+++ b/test/reward_by_block_test.js
@@ -178,8 +178,8 @@ contract('RewardByBlock [all features]', function (accounts) {
 
     it('should assign rewards to extra receivers and clear extra receivers list', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[1]);
-      await rewardByBlock.addExtraReceiver(accounts[2], 2, {from: accounts[1]}).should.be.fulfilled;
-      await rewardByBlock.addExtraReceiver(accounts[3], 3, {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
 
       await rewardByBlock.setSystemAddress(systemAddress);
       let result = await rewardByBlock.reward(
@@ -198,8 +198,8 @@ contract('RewardByBlock [all features]', function (accounts) {
       (await rewardByBlock.extraReceiversAmounts.call(accounts[3])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
 
-      await rewardByBlock.addExtraReceiver(accounts[2], 2, {from: accounts[1]}).should.be.fulfilled;
-      await rewardByBlock.addExtraReceiver(accounts[3], 3, {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
       result = await rewardByBlock.reward(
         [miningKey],
         [0],
@@ -220,16 +220,16 @@ contract('RewardByBlock [all features]', function (accounts) {
 
   describe('#addExtraReceiver', async () => {
     it('may only be called by bridge contract', async () => {
-      await rewardByBlock.addExtraReceiver(accounts[1], 1).should.be.rejectedWith(ERROR_MSG);
+      await rewardByBlock.addExtraReceiver(1, accounts[1]).should.be.rejectedWith(ERROR_MSG);
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
-      await rewardByBlock.addExtraReceiver(accounts[1], 1, {from: accounts[2]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(1, accounts[1], {from: accounts[2]}).should.be.fulfilled;
     });
 
     it('should revert if receiver address is 0x0', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
-        '0x0000000000000000000000000000000000000000',
         1,
+        '0x0000000000000000000000000000000000000000',
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -237,8 +237,8 @@ contract('RewardByBlock [all features]', function (accounts) {
     it('should revert if amount is 0', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
-        accounts[1],
         0,
+        accounts[1],
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -246,13 +246,13 @@ contract('RewardByBlock [all features]', function (accounts) {
     it('can only be called once for the same recipient', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
-        accounts[1],
         1,
+        accounts[1],
         {from: accounts[2]}
       ).should.be.fulfilled;
       await rewardByBlock.addExtraReceiver(
-        accounts[1],
         1,
+        accounts[1],
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -262,7 +262,7 @@ contract('RewardByBlock [all features]', function (accounts) {
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
 
-      let result = await rewardByBlock.addExtraReceiver(accounts[2], 2, {from: accounts[1]}).should.be.fulfilled;
+      let result = await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
       (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[2]);
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(2);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(1);
@@ -270,7 +270,7 @@ contract('RewardByBlock [all features]', function (accounts) {
       result.logs[0].args.receiver.should.be.equal(accounts[2]);
       result.logs[0].args.amount.should.be.bignumber.equal(2);
 
-      result = await rewardByBlock.addExtraReceiver(accounts[3], 3, {from: accounts[1]}).should.be.fulfilled;
+      result = await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
       (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[2]);
       (await rewardByBlock.extraReceivers.call(1)).should.be.equal(accounts[3]);
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(2);

--- a/test/reward_by_block_upgrade_test.js
+++ b/test/reward_by_block_upgrade_test.js
@@ -183,8 +183,8 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
 
     it('should assign rewards to extra receivers and clear extra receivers list', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[1]);
-      await rewardByBlock.addExtraReceiver(accounts[2], 2, {from: accounts[1]}).should.be.fulfilled;
-      await rewardByBlock.addExtraReceiver(accounts[3], 3, {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
 
       await rewardByBlock.setSystemAddress(systemAddress);
       let result = await rewardByBlock.reward(
@@ -203,8 +203,8 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
       (await rewardByBlock.extraReceiversAmounts.call(accounts[3])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
 
-      await rewardByBlock.addExtraReceiver(accounts[2], 2, {from: accounts[1]}).should.be.fulfilled;
-      await rewardByBlock.addExtraReceiver(accounts[3], 3, {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
       result = await rewardByBlock.reward(
         [miningKey],
         [0],
@@ -225,16 +225,16 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
 
   describe('#addExtraReceiver', async () => {
     it('may only be called by bridge contract', async () => {
-      await rewardByBlock.addExtraReceiver(accounts[1], 1).should.be.rejectedWith(ERROR_MSG);
+      await rewardByBlock.addExtraReceiver(1, accounts[1]).should.be.rejectedWith(ERROR_MSG);
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
-      await rewardByBlock.addExtraReceiver(accounts[1], 1, {from: accounts[2]}).should.be.fulfilled;
+      await rewardByBlock.addExtraReceiver(1, accounts[1], {from: accounts[2]}).should.be.fulfilled;
     });
 
     it('should revert if receiver address is 0x0', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
-        '0x0000000000000000000000000000000000000000',
         1,
+        '0x0000000000000000000000000000000000000000',
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -242,8 +242,8 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
     it('should revert if amount is 0', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
-        accounts[1],
         0,
+        accounts[1],
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -251,13 +251,13 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
     it('can only be called once for the same recipient', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
-        accounts[1],
         1,
+        accounts[1],
         {from: accounts[2]}
       ).should.be.fulfilled;
       await rewardByBlock.addExtraReceiver(
-        accounts[1],
         1,
+        accounts[1],
         {from: accounts[2]}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -267,7 +267,7 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
 
-      let result = await rewardByBlock.addExtraReceiver(accounts[2], 2, {from: accounts[1]}).should.be.fulfilled;
+      let result = await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
       (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[2]);
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(2);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(1);
@@ -275,7 +275,7 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
       result.logs[0].args.receiver.should.be.equal(accounts[2]);
       result.logs[0].args.amount.should.be.bignumber.equal(2);
 
-      result = await rewardByBlock.addExtraReceiver(accounts[3], 3, {from: accounts[1]}).should.be.fulfilled;
+      result = await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
       (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[2]);
       (await rewardByBlock.extraReceivers.call(1)).should.be.equal(accounts[3]);
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(2);

--- a/test/voting_to_change_keys_test.js
+++ b/test/voting_to_change_keys_test.js
@@ -86,33 +86,33 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[4],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[4],       // _affectedKey
+        accounts[5],       // _miningKey
         {from: miningKeyForVotingKey}
       ).should.be.rejectedWith(ERROR_MSG);
 
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[3],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[3],       // _affectedKey
+        accounts[5],       // _miningKey
         {from: votingKey}
       ).should.be.rejectedWith(ERROR_MSG);
 
       const {logs} = await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[4],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[4],       // _affectedKey
+        accounts[5],       // _miningKey
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -128,13 +128,40 @@ contract('Voting to change keys [all features]', function (accounts) {
     it('should not let create voting with invalid duration', async () => {
       VOTING_START_DATE = moment.utc().add(10, 'days').unix();
       VOTING_END_DATE = moment.utc().add(2, 'seconds').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[1], 1, accounts[2], 1, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        1, // _affectedKeyType
+        "memo",
+        accounts[1], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
       VOTING_START_DATE = 0
       VOTING_END_DATE = moment.utc().add(2, 'seconds').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[1], 1, accounts[2], 1, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        1, // _affectedKeyType
+        "memo",
+        accounts[1], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
       VOTING_START_DATE = moment.utc().add(2, 'seconds').unix();
       VOTING_END_DATE = 0
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[1], 1, accounts[2], 1, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        1, // _affectedKeyType
+        "memo",
+        accounts[1], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
     })
     it('should not let add votingKey for MoC', async () => {
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
@@ -144,8 +171,26 @@ contract('Voting to change keys [all features]', function (accounts) {
       await proxyStorageMock.setVotingContractMock(voting.address);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, masterOfCeremony, 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        masterOfCeremony, // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.fulfilled;
     })
     it('should not let add votingKey for 0x0', async () => {
       await proxyStorageMock.setVotingContractMock(accounts[0]);
@@ -155,8 +200,26 @@ contract('Voting to change keys [all features]', function (accounts) {
       await proxyStorageMock.setVotingContractMock(voting.address);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        '0x0000000000000000000000000000000000000000', // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.fulfilled;
     })
     it('should not let add payoutKey for 0x0', async () => {
       await proxyStorageMock.setVotingContractMock(accounts[0]);
@@ -166,8 +229,26 @@ contract('Voting to change keys [all features]', function (accounts) {
       await proxyStorageMock.setVotingContractMock(voting.address);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        accounts[5],
+        '0x0000000000000000000000000000000000000000',
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        accounts[5],
+        accounts[2],
+        {from: votingKey}
+      ).should.be.fulfilled;
     })
     it('should not let create more ballots than the limit', async () => {
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
@@ -175,12 +256,39 @@ contract('Voting to change keys [all features]', function (accounts) {
       await addVotingKey(votingKey, accounts[1]);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[2], 1, "memo", {from: votingKey});
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[2], 1, "memo", {from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3],
+        accounts[2],
+        {from: votingKey}
+      );
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3],
+        accounts[2],
+        {from: votingKey}
+      );
       new web3.BigNumber(200).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
       await addValidators({proxyStorageMock, keysManager, poaNetworkConsensusMock}); //add 100 validators, so total will be 101 validator
       new web3.BigNumber(1).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[2], 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG)
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3],
+        accounts[2],
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG)
     })
   })
 
@@ -201,19 +309,19 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: miningKeyForVotingKey}
       ).should.be.rejectedWith(ERROR_MSG);
       const {logs} = await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
       
@@ -248,10 +356,10 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         votingKey,         // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -260,19 +368,19 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[6],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.rejectedWith(ERROR_MSG);
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
     });
@@ -292,10 +400,10 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[7],       // _newMiningKey
         accounts[8],       // _newVotingKey
         accounts[9],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -339,10 +447,10 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[7],       // _newMiningKey
         accounts[8],       // _newVotingKey
         accounts[9],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -374,11 +482,11 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[7],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[7],       // _miningKey
         2,                 // _ballotType (KeyRemoval)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[7],       // _affectedKey
+        accounts[7],       // _miningKey
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -414,7 +522,16 @@ contract('Voting to change keys [all features]', function (accounts) {
       await addMiningKey(accounts[1]);
       await addVotingKey(votingKey, accounts[1]);
       id = await voting.nextBallotId.call();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[1], 1, "memo", {from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3], 
+        accounts[1],
+        {from: votingKey}
+      );
     })
 
     it('should let a validator to vote', async () => {
@@ -524,7 +641,16 @@ contract('Voting to change keys [all features]', function (accounts) {
     })
     
     it('happy path - no action since it did not meet minimum number of totalVoters', async () => {
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, payoutKeyToAdd, 3, accounts[1], 1, "memo", {from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        payoutKeyToAdd,
+        accounts[1],
+        {from: votingKey}
+      );
       let activeBallotsLength = await voting.activeBallotsLength.call();
       votingId = await voting.activeBallots.call(activeBallotsLength.toNumber() - 1);
       await voting.finalize(votingId, { from: votingKey }).should.be.rejectedWith(ERROR_MSG);
@@ -650,8 +776,16 @@ contract('Voting to change keys [all features]', function (accounts) {
         
       })
       await voting.setTime(VOTING_START_DATE - 1);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, miningKey, 1, accounts[5], 3, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        3,
+        1,
+        "memo",
+        miningKey,
+        accounts[5],
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
     })
     it('finalize addition of MiningKey', async () => {
       await proxyStorageMock.setVotingContractMock(voting.address);
@@ -867,8 +1001,26 @@ contract('Voting to change keys [all features]', function (accounts) {
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
 
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, affectedKey, 1, miningKey, 3, "memo",{from: votingKey});
-      await voting.createBallot(VOTING_START_DATE+2, VOTING_END_DATE+2, affectedKey, 1, miningKey, 2, "memo",{from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        3,
+        1,
+        "memo",
+        affectedKey,
+        miningKey,
+        {from: votingKey}
+      );
+      await voting.createBallot(
+        VOTING_START_DATE+2,
+        VOTING_END_DATE+2,
+        2,
+        1,
+        "memo",
+        affectedKey,
+        miningKey,
+        {from: votingKey}
+      );
       const activeBallotsLength = await voting.activeBallotsLength.call();
       votingId = await voting.activeBallots.call(activeBallotsLength.toNumber() - 2);
       let votingIdForSecond = votingId.add(1);
@@ -900,11 +1052,11 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        affectedKey,       // address _affectedKey
-        1,                 // uint256 _affectedKeyType (MiningKey)
-        miningKey,         // address _miningKey
         3,                 // uint256 _ballotType (KeySwap)
+        1,                 // uint256 _affectedKeyType (MiningKey)
         "memo",            // string _memo
+        affectedKey,       // address _affectedKey
+        miningKey,         // address _miningKey
         {from: votingKey3}
       ).should.be.fulfilled;
 
@@ -935,11 +1087,11 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        affectedKey,       // address _affectedKey
-        1,                 // uint256 _affectedKeyType (MiningKey)
-        miningKey,         // address _miningKey
         3,                 // uint256 _ballotType (KeySwap)
+        1,                 // uint256 _affectedKeyType (MiningKey)
         "memo",            // string _memo
+        affectedKey,       // address _affectedKey
+        miningKey,         // address _miningKey
         {from: votingKey3}
       ).should.be.fulfilled;
 
@@ -979,11 +1131,11 @@ contract('Voting to change keys [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[7],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[2],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[7],       // _affectedKey
+        accounts[2],       // _miningKey
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -1111,7 +1263,16 @@ contract('Voting to change keys [all features]', function (accounts) {
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
 
       await votingEternalStorage.setProxyStorage(proxyStorageMock.address);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, payoutKeyToAdd, 3, accounts[1], 1, "memo", {from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        payoutKeyToAdd,
+        accounts[1],
+        {from: votingKey}
+      );
 
       const activeBallotsLength = await voting.activeBallotsLength.call();
       const votingId = await voting.activeBallots.call(activeBallotsLength.toNumber() - 1);
@@ -1166,11 +1327,11 @@ async function deployAndTestBallot({_affectedKey, _affectedKeyType, _miningKey, 
   await voting.createBallot(
     VOTING_START_DATE,
     VOTING_END_DATE,
-    _affectedKey,
-    _affectedKeyType,
-    _miningKey,
     _ballotType,
+    _affectedKeyType,
     "memo",
+    _affectedKey,
+    _miningKey,
     {from: votingKey}
   );
 
@@ -1190,11 +1351,11 @@ async function deployAndTestBallot({_affectedKey, _affectedKeyType, _miningKey, 
     await voting.createBallot(
       VOTING_START_DATE+10,
       VOTING_END_DATE,
-      _affectedKey,
-      _affectedKeyType,
-      _miningKey,
       _ballotType,
+      _affectedKeyType,
       "memo",
+      _affectedKey,
+      _miningKey,
       {from: votingKey}
     );
     new web3.BigNumber(_ballotType).should.be.bignumber.equal(await voting.getBallotType.call(secondVotingId));

--- a/test/voting_to_change_keys_upgrade_test.js
+++ b/test/voting_to_change_keys_upgrade_test.js
@@ -93,33 +93,33 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[4],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[4],       // _affectedKey
+        accounts[5],       // _miningKey
         {from: miningKeyForVotingKey}
       ).should.be.rejectedWith(ERROR_MSG);
 
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[3],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[3],       // _affectedKey
+        accounts[5],       // _miningKey
         {from: votingKey}
       ).should.be.rejectedWith(ERROR_MSG);
 
       const {logs} = await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[4],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[5],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[4],       // _affectedKey
+        accounts[5],       // _miningKey
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -135,13 +135,40 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
     it('should not let create voting with invalid duration', async () => {
       VOTING_START_DATE = moment.utc().add(10, 'days').unix();
       VOTING_END_DATE = moment.utc().add(2, 'seconds').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[1], 1, accounts[2], 1, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        1, // _affectedKeyType
+        "memo",
+        accounts[1], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
       VOTING_START_DATE = 0
       VOTING_END_DATE = moment.utc().add(2, 'seconds').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[1], 1, accounts[2], 1, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        1, // _affectedKeyType
+        "memo",
+        accounts[1], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
       VOTING_START_DATE = moment.utc().add(2, 'seconds').unix();
       VOTING_END_DATE = 0
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[1], 1, accounts[2], 1, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        1, // _affectedKeyType
+        "memo",
+        accounts[1], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
     })
     it('should not let add votingKey for MoC', async () => {
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
@@ -151,8 +178,26 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await proxyStorageMock.setVotingContractMock(voting.address);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, masterOfCeremony, 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        masterOfCeremony, // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.fulfilled;
     })
     it('should not let add votingKey for 0x0', async () => {
       await proxyStorageMock.setVotingContractMock(accounts[0]);
@@ -162,8 +207,26 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await proxyStorageMock.setVotingContractMock(voting.address);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        '0x0000000000000000000000000000000000000000', // _miningKey
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1, // _ballotType
+        2, // _affectedKeyType
+        "memo",
+        accounts[5], // _affectedKey
+        accounts[2], // _miningKey
+        {from: votingKey}
+      ).should.be.fulfilled;
     })
     it('should not let add payoutKey for 0x0', async () => {
       await proxyStorageMock.setVotingContractMock(accounts[0]);
@@ -173,8 +236,26 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await proxyStorageMock.setVotingContractMock(voting.address);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, '0x0000000000000000000000000000000000000000', 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[2], 1, "memo", {from: votingKey}).should.be.fulfilled;
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        accounts[5],
+        '0x0000000000000000000000000000000000000000',
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        accounts[5],
+        accounts[2],
+        {from: votingKey}
+      ).should.be.fulfilled;
     })
     it('should not let create more ballots than the limit', async () => {
       await proxyStorageMock.setVotingContractMock(masterOfCeremony);
@@ -182,12 +263,39 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await addVotingKey(votingKey, accounts[1]);
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[2], 1, "memo", {from: votingKey});
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[2], 1, "memo", {from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3],
+        accounts[2],
+        {from: votingKey}
+      );
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3],
+        accounts[2],
+        {from: votingKey}
+      );
       new web3.BigNumber(200).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
       await addValidators({proxyStorageMock, keysManager, poaNetworkConsensusMock}); //add 100 validators, so total will be 101 validator
       new web3.BigNumber(1).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[2], 1, "memo", {from: votingKey}).should.be.rejectedWith(ERROR_MSG)
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3],
+        accounts[2],
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG)
     })
   })
 
@@ -208,19 +316,19 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: miningKeyForVotingKey}
       ).should.be.rejectedWith(ERROR_MSG);
       const {logs} = await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
       
@@ -255,10 +363,10 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         votingKey,         // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.rejectedWith(ERROR_MSG);
     });
@@ -267,19 +375,19 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[6],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.rejectedWith(ERROR_MSG);
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[3],       // _newMiningKey
         accounts[4],       // _newVotingKey
         accounts[5],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
     });
@@ -299,10 +407,10 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[7],       // _newMiningKey
         accounts[8],       // _newVotingKey
         accounts[9],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -346,10 +454,10 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallotToAddNewValidator(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
+        "memo",            // _memo
         accounts[7],       // _newMiningKey
         accounts[8],       // _newVotingKey
         accounts[9],       // _newPayoutKey
-        "memo",            // _memo
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -381,11 +489,11 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[7],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[7],       // _miningKey
         2,                 // _ballotType (KeyRemoval)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[7],       // _affectedKey
+        accounts[7],       // _miningKey
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -421,7 +529,16 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await addMiningKey(accounts[1]);
       await addVotingKey(votingKey, accounts[1]);
       id = await voting.nextBallotId.call();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[3], 1, accounts[1], 1, "memo", {from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        1,
+        "memo",
+        accounts[3], 
+        accounts[1],
+        {from: votingKey}
+      );
     })
 
     it('should let a validator to vote', async () => {
@@ -531,7 +648,16 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
     })
     
     it('happy path - no action since it did not meet minimum number of totalVoters', async () => {
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, payoutKeyToAdd, 3, accounts[1], 1, "memo", {from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        payoutKeyToAdd,
+        accounts[1],
+        {from: votingKey}
+      );
       let activeBallotsLength = await voting.activeBallotsLength.call();
       votingId = await voting.activeBallots.call(activeBallotsLength.toNumber() - 1);
       await voting.finalize(votingId, { from: votingKey }).should.be.rejectedWith(ERROR_MSG);
@@ -657,8 +783,16 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
         
       })
       await voting.setTime(VOTING_START_DATE - 1);
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, miningKey, 1, accounts[5], 3, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG);
-      
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        3,
+        1,
+        "memo",
+        miningKey,
+        accounts[5],
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG);
     })
     it('finalize addition of MiningKey', async () => {
       await proxyStorageMock.setVotingContractMock(voting.address);
@@ -874,8 +1008,26 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await poaNetworkConsensusMock.setSystemAddress(accounts[0]);
       await poaNetworkConsensusMock.finalizeChange().should.be.fulfilled;
 
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, affectedKey, 1, miningKey, 3, "memo",{from: votingKey});
-      await voting.createBallot(VOTING_START_DATE+2, VOTING_END_DATE+2, affectedKey, 1, miningKey, 2, "memo",{from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        3,
+        1,
+        "memo",
+        affectedKey,
+        miningKey,
+        {from: votingKey}
+      );
+      await voting.createBallot(
+        VOTING_START_DATE+2,
+        VOTING_END_DATE+2,
+        2,
+        1,
+        "memo",
+        affectedKey,
+        miningKey,
+        {from: votingKey}
+      );
       const activeBallotsLength = await voting.activeBallotsLength.call();
       votingId = await voting.activeBallots.call(activeBallotsLength.toNumber() - 2);
       let votingIdForSecond = votingId.add(1);
@@ -907,11 +1059,11 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        affectedKey,       // address _affectedKey
-        1,                 // uint256 _affectedKeyType (MiningKey)
-        miningKey,         // address _miningKey
         3,                 // uint256 _ballotType (KeySwap)
+        1,                 // uint256 _affectedKeyType (MiningKey)
         "memo",            // string _memo
+        affectedKey,       // address _affectedKey
+        miningKey,         // address _miningKey
         {from: votingKey3}
       ).should.be.fulfilled;
 
@@ -942,11 +1094,11 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        affectedKey,       // address _affectedKey
-        1,                 // uint256 _affectedKeyType (MiningKey)
-        miningKey,         // address _miningKey
         3,                 // uint256 _ballotType (KeySwap)
+        1,                 // uint256 _affectedKeyType (MiningKey)
         "memo",            // string _memo
+        affectedKey,       // address _affectedKey
+        miningKey,         // address _miningKey
         {from: votingKey3}
       ).should.be.fulfilled;
 
@@ -986,11 +1138,11 @@ contract('Voting to change keys upgraded [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // _startTime
         VOTING_END_DATE,   // _endTime
-        accounts[7],       // _affectedKey
-        1,                 // _affectedKeyType (MiningKey)
-        accounts[2],       // _miningKey
         1,                 // _ballotType (KeyAdding)
+        1,                 // _affectedKeyType (MiningKey)
         "memo",            // _memo
+        accounts[7],       // _affectedKey
+        accounts[2],       // _miningKey
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -1072,11 +1224,11 @@ async function deployAndTestBallot({_affectedKey, _affectedKeyType, _miningKey, 
   await voting.createBallot(
     VOTING_START_DATE,
     VOTING_END_DATE,
-    _affectedKey,
-    _affectedKeyType,
-    _miningKey,
     _ballotType,
+    _affectedKeyType,
     "memo",
+    _affectedKey,
+    _miningKey,
     {from: votingKey}
   );
 
@@ -1096,11 +1248,11 @@ async function deployAndTestBallot({_affectedKey, _affectedKeyType, _miningKey, 
     await voting.createBallot(
       VOTING_START_DATE+10,
       VOTING_END_DATE,
-      _affectedKey,
-      _affectedKeyType,
-      _miningKey,
       _ballotType,
+      _affectedKeyType,
       "memo",
+      _affectedKey,
+      _miningKey,
       {from: votingKey}
     );
     new web3.BigNumber(_ballotType).should.be.bignumber.equal(await voting.getBallotType.call(secondVotingId));

--- a/test/voting_to_change_min_threshold_test.js
+++ b/test/voting_to_change_min_threshold_test.js
@@ -338,7 +338,16 @@ contract('VotingToChangeMinThreshold [all features]', function (accounts) {
       await votingForKeys.migrateDisable();
 
       const nextId = await votingForKeys.nextBallotId.call();
-      await votingForKeys.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[1], 1, "memo", {from: votingKey});
+      await votingForKeys.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        accounts[5],
+        accounts[1],
+        {from: votingKey}
+      );
       const minThresholdVotingForKeys = await votingForKeys.getMinThresholdOfVoters.call(nextId);
       minThresholdVotingForKeys.should.be.bignumber.equal(proposedValue);
     })

--- a/test/voting_to_change_min_threshold_upgrade_test.js
+++ b/test/voting_to_change_min_threshold_upgrade_test.js
@@ -345,7 +345,16 @@ contract('VotingToChangeMinThreshold upgraded [all features]', function (account
       await votingForKeys.migrateDisable();
 
       const nextId = await votingForKeys.nextBallotId.call();
-      await votingForKeys.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 3, accounts[1], 1, "memo", {from: votingKey});
+      await votingForKeys.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        3,
+        "memo",
+        accounts[5],
+        accounts[1],
+        {from: votingKey}
+      );
       const minThresholdVotingForKeys = await votingForKeys.getMinThresholdOfVoters.call(nextId);
       minThresholdVotingForKeys.should.be.bignumber.equal(proposedValue);
     })

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -107,12 +107,13 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       id = await voting.nextBallotId.call();
     })
     it('happy path', async () => {
-      // uint256 _startTime,
-      // uint256 _endTime,
-      // address _proposedValue,
-      // uint256 _contractType
       const {logs} = await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
       const keysManagerFromContract = await voting.getKeysManager.call();
       const ballotInfo = await voting.getBallotInfo.call(id, votingKey);
@@ -147,11 +148,24 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       logs[0].args.creator.should.be.equal(votingKey);
     })
     it('proposed address should not be 0x0', async () => {
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, '0x0000000000000000000000000000000000000000', 2, "memo",{ from: votingKey }).should.be.fulfilled.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        '0x0000000000000000000000000000000000000000',
+        { from: votingKey }
+      ).should.be.fulfilled.rejectedWith(ERROR_MSG);
     })
     it('can create multiple ballots', async () => {
       const { logs } = await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo",{ from: votingKey });
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[5],
+        { from: votingKey }
+      );
       const keysManagerFromContract = await voting.getKeysManager.call();
 
       let activeBallotsLength = await voting.activeBallotsLength.call();
@@ -161,7 +175,12 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       nextBallotId.should.be.bignumber.equal(1);
 
       await voting.createBallot(
-        VOTING_START_DATE + 1, VOTING_END_DATE + 1, accounts[5], 2, "memo",{ from: votingKey }
+        VOTING_START_DATE + 1,
+        VOTING_END_DATE + 1,
+        2,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
 
       const ballotInfo = await voting.getBallotInfo.call(nextBallotId, votingKey);
@@ -187,13 +206,34 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
     it('should not let create more ballots than the limit', async () => {
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, "memo",{from: votingKey});
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, "memo",{from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        accounts[5],
+        {from: votingKey}
+      );
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        accounts[5],
+        {from: votingKey}
+      );
       // we have 1 validator, so 200 limit / 1 = 200
       new web3.BigNumber(200).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
       await addValidators({proxyStorageMock, keysManager, poaNetworkConsensusMock}); // add 100 validators, so total will be 101 validator
       new web3.BigNumber(1).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG)
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        accounts[5],
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG)
     })
   })
 
@@ -207,7 +247,12 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       await addVotingKey(votingKey, accounts[1]);
       id = await voting.nextBallotId.call();
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
     })
 
@@ -322,7 +367,12 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       let contractType = 1; //keysManager
       votingId = await voting.nextBallotId.call();
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], contractType, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        contractType,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
       await voting.finalize(votingId, { from: votingKey }).should.be.rejectedWith(ERROR_MSG);
       await voting.setTime(VOTING_START_DATE);
@@ -429,10 +479,20 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       let contractType1 = 100;
       let contractType2 = 101;
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, newAddress1, contractType1, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        contractType1,
+        "memo",
+        newAddress1,
+        { from: votingKey }
       );
       await voting.createBallot(
-        VOTING_START_DATE+2, VOTING_END_DATE+2, newAddress2, contractType2, "memo", { from: votingKey }
+        VOTING_START_DATE+2,
+        VOTING_END_DATE+2,
+        contractType2,
+        "memo",
+        newAddress2,
+        { from: votingKey }
       );
 
       const activeBallotsLength = await voting.activeBallotsLength.call();
@@ -498,9 +558,9 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        accounts[7],       // address _proposedValue
         100,               // uint256 _contractType
         "memo",            // string _memo
+        accounts[7],       // address _proposedValue
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -531,9 +591,9 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        accounts[8],       // address _proposedValue
         100,               // uint256 _contractType
         "memo",            // string _memo
+        accounts[8],       // address _proposedValue
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -573,7 +633,12 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       const id = await voting.nextBallotId.call();
 
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[7], 1, "memo", {from: votingKey}
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[7],
+        {from: votingKey}
       ).should.be.fulfilled;
 
       await voting.setTime(VOTING_START_DATE);
@@ -692,7 +757,12 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       await proxyStorageMock.setVotingContractMock(votingForKeysEternalStorage.address);
       await votingEternalStorage.setProxyStorage(proxyStorageMock.address);
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       ).should.be.fulfilled;
       await votingEternalStorage.setProxyStorage(proxyStorageStubAddress);
       let votingNew = await VotingToChangeProxyAddressNew.new();
@@ -727,7 +797,12 @@ async function deployAndTest({
 }) {
   votingId = await voting.nextBallotId.call();
   await voting.createBallot(
-    VOTING_START_DATE, VOTING_END_DATE, newAddress, contractType, "memo", { from: votingKey }
+    VOTING_START_DATE,
+    VOTING_END_DATE,
+    contractType,
+    "memo",
+    newAddress,
+    { from: votingKey }
   );
   await voting.setTime(VOTING_START_DATE);
   await voting.vote(votingId, choice.accept, { from: votingKey }).should.be.fulfilled;

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -114,12 +114,13 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       id = await voting.nextBallotId.call();
     })
     it('happy path', async () => {
-      // uint256 _startTime,
-      // uint256 _endTime,
-      // address _proposedValue,
-      // uint256 _contractType
       const {logs} = await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
       const keysManagerFromContract = await voting.getKeysManager.call();
       const ballotInfo = await voting.getBallotInfo.call(id, votingKey);
@@ -154,11 +155,24 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       logs[0].args.creator.should.be.equal(votingKey);
     })
     it('proposed address should not be 0x0', async () => {
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, '0x0000000000000000000000000000000000000000', 2, "memo",{ from: votingKey }).should.be.fulfilled.rejectedWith(ERROR_MSG);
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        '0x0000000000000000000000000000000000000000',
+        { from: votingKey }
+      ).should.be.fulfilled.rejectedWith(ERROR_MSG);
     })
     it('can create multiple ballots', async () => {
       const { logs } = await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo",{ from: votingKey });
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[5],
+        { from: votingKey }
+      );
       const keysManagerFromContract = await voting.getKeysManager.call();
 
       let activeBallotsLength = await voting.activeBallotsLength.call();
@@ -168,7 +182,12 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       nextBallotId.should.be.bignumber.equal(1);
 
       await voting.createBallot(
-        VOTING_START_DATE + 1, VOTING_END_DATE + 1, accounts[5], 2, "memo",{ from: votingKey }
+        VOTING_START_DATE + 1,
+        VOTING_END_DATE + 1,
+        2,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
 
       const ballotInfo = await voting.getBallotInfo.call(nextBallotId, votingKey);
@@ -194,13 +213,34 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
     it('should not let create more ballots than the limit', async () => {
       VOTING_START_DATE = moment.utc().add(20, 'seconds').unix();
       VOTING_END_DATE = moment.utc().add(10, 'days').unix();
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, "memo",{from: votingKey});
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, "memo",{from: votingKey});
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        accounts[5],
+        {from: votingKey}
+      );
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        accounts[5],
+        {from: votingKey}
+      );
       // we have 1 validator, so 200 limit / 1 = 200
       new web3.BigNumber(200).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
       await addValidators({proxyStorageMock, keysManager, poaNetworkConsensusMock}); // add 100 validators, so total will be 101 validator
       new web3.BigNumber(1).should.be.bignumber.equal(await voting.getBallotLimitPerValidator.call());
-      await voting.createBallot(VOTING_START_DATE, VOTING_END_DATE, accounts[5], 2, "memo",{from: votingKey}).should.be.rejectedWith(ERROR_MSG)
+      await voting.createBallot(
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        2,
+        "memo",
+        accounts[5],
+        {from: votingKey}
+      ).should.be.rejectedWith(ERROR_MSG)
     })
   })
 
@@ -214,7 +254,12 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       await addVotingKey(votingKey, accounts[1]);
       id = await voting.nextBallotId.call();
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], 1, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
     })
 
@@ -329,7 +374,12 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       let contractType = 1; //keysManager
       votingId = await voting.nextBallotId.call();
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[5], contractType, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        contractType,
+        "memo",
+        accounts[5],
+        { from: votingKey }
       );
       await voting.finalize(votingId, { from: votingKey }).should.be.rejectedWith(ERROR_MSG);
       await voting.setTime(VOTING_START_DATE);
@@ -436,10 +486,20 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       let contractType1 = 100;
       let contractType2 = 101;
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, newAddress1, contractType1, "memo", { from: votingKey }
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        contractType1,
+        "memo",
+        newAddress1,
+        { from: votingKey }
       );
       await voting.createBallot(
-        VOTING_START_DATE+2, VOTING_END_DATE+2, newAddress2, contractType2, "memo", { from: votingKey }
+        VOTING_START_DATE+2,
+        VOTING_END_DATE+2,
+        contractType2,
+        "memo",
+        newAddress2,
+        { from: votingKey }
       );
 
       const activeBallotsLength = await voting.activeBallotsLength.call();
@@ -505,9 +565,9 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        accounts[7],       // address _proposedValue
         100,               // uint256 _contractType
         "memo",            // string _memo
+        accounts[7],       // address _proposedValue
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -538,9 +598,9 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       await voting.createBallot(
         VOTING_START_DATE, // uint256 _startTime
         VOTING_END_DATE,   // uint256 _endTime
-        accounts[8],       // address _proposedValue
         100,               // uint256 _contractType
         "memo",            // string _memo
+        accounts[8],       // address _proposedValue
         {from: votingKey}
       ).should.be.fulfilled;
 
@@ -580,7 +640,12 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       const id = await voting.nextBallotId.call();
 
       await voting.createBallot(
-        VOTING_START_DATE, VOTING_END_DATE, accounts[7], 1, "memo", {from: votingKey}
+        VOTING_START_DATE,
+        VOTING_END_DATE,
+        1,
+        "memo",
+        accounts[7],
+        {from: votingKey}
       ).should.be.fulfilled;
 
       await voting.setTime(VOTING_START_DATE);
@@ -652,7 +717,12 @@ async function deployAndTest({
 }) {
   votingId = await voting.nextBallotId.call();
   await voting.createBallot(
-    VOTING_START_DATE, VOTING_END_DATE, newAddress, contractType, "memo", { from: votingKey }
+    VOTING_START_DATE,
+    VOTING_END_DATE,
+    contractType,
+    "memo",
+    newAddress,
+    { from: votingKey }
   );
   await voting.setTime(VOTING_START_DATE);
   await voting.vote(votingId, choice.accept, { from: votingKey }).should.be.fulfilled;

--- a/test/voting_to_manage_emission_funds_test.js
+++ b/test/voting_to_manage_emission_funds_test.js
@@ -94,23 +94,23 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
     emissionReleaseThreshold = moment.duration(3, 'months').asSeconds();
     distributionThreshold = moment.duration(7, 'days').asSeconds();
     await voting.init(
-      emissionFunds.address,
       emissionReleaseTime,
       emissionReleaseThreshold,
       distributionThreshold,
+      emissionFunds.address,
       {from: accounts[8]}
     ).should.be.rejectedWith(ERROR_MSG);
     await voting.init(
-      emissionFunds.address,
       emissionReleaseTime,
       emissionReleaseThreshold,
-      300
+      300,
+      emissionFunds.address
     ).should.be.rejectedWith(ERROR_MSG);
     await voting.init(
-      emissionFunds.address,
       emissionReleaseTime,
       emissionReleaseThreshold,
-      distributionThreshold
+      distributionThreshold,
+      emissionFunds.address
     ).should.be.fulfilled;
 
     rewardByBlock = await RewardByBlock.new();
@@ -157,10 +157,10 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
     });
     it('cannot be called more than once', async () => {
       await voting.init(
-        emissionFunds.address,
         emissionReleaseTime,
         emissionReleaseThreshold,
-        distributionThreshold
+        distributionThreshold,
+        emissionFunds.address
       ).should.be.rejectedWith(ERROR_MSG);
     });
   });
@@ -1035,10 +1035,10 @@ contract('VotingToManageEmissionFunds [all features]', function (accounts) {
       votingEternalStorage = await EternalStorageProxy.new(proxyStorageStubAddress, voting.address);
       voting = await VotingToManageEmissionFunds.at(votingEternalStorage.address);
       await voting.init(
-        emissionFunds.address,
         emissionReleaseTime,
         emissionReleaseThreshold,
-        distributionThreshold
+        distributionThreshold,
+        emissionFunds.address
       ).should.be.fulfilled;
     });
     it('may only be called by ProxyStorage', async () => {

--- a/test/voting_to_manage_emission_funds_upgrade_test.js
+++ b/test/voting_to_manage_emission_funds_upgrade_test.js
@@ -94,23 +94,23 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
     emissionReleaseThreshold = moment.duration(3, 'months').asSeconds();
     distributionThreshold = moment.duration(7, 'days').asSeconds();
     await voting.init(
-      emissionFunds.address,
       emissionReleaseTime,
       emissionReleaseThreshold,
       distributionThreshold,
+      emissionFunds.address,
       {from: accounts[8]}
     ).should.be.rejectedWith(ERROR_MSG);
     await voting.init(
-      emissionFunds.address,
       emissionReleaseTime,
       emissionReleaseThreshold,
-      300
+      300,
+      emissionFunds.address
     ).should.be.rejectedWith(ERROR_MSG);
     await voting.init(
-      emissionFunds.address,
       emissionReleaseTime,
       emissionReleaseThreshold,
-      distributionThreshold
+      distributionThreshold,
+      emissionFunds.address
     ).should.be.fulfilled;
 
     rewardByBlock = await RewardByBlock.new();
@@ -164,10 +164,10 @@ contract('VotingToManageEmissionFunds upgraded [all features]', function (accoun
     });
     it('cannot be called more than once', async () => {
       await voting.init(
-        emissionFunds.address,
         emissionReleaseTime,
         emissionReleaseThreshold,
-        distributionThreshold
+        distributionThreshold,
+        emissionFunds.address
       ).should.be.rejectedWith(ERROR_MSG);
     });
   });


### PR DESCRIPTION
**(Mandatory) Description**

The changes made within this PR:

1. `address` arguments have been put at the end of the argument list of several functions to limit the risk of `short address attack`:

- `BallotsStorage.areKeysBallotParamsValid`
- `BallotsStorage._areKeyAddingBallotParamsValid`
- `BallotsStorage._areKeyRemovalBallotParamsValid`
- `BallotsStorage._areKeySwapBallotParamsValid`
- `KeysManager._setInitialKeyStatus`
- `RewardByBlock.addExtraReceiver`
- `RewardByBlock._setExtraReceiverAmount`
- `VotingToChangeKeys.createBallot`
- `VotingToChangeKeys.createBallotToAddNewValidator`
- `VotingToChangeProxyAddress.createBallot`
- `VotingToManageEmissionFunds.init`

2. Checking of `msg.data.length` has been added to `KeysManager.checkIfMiningExisted` function.

3. `isValidator` function has been removed from `ProxyStorage` contract. Now `ProxyStorage.initializeAddresses` function can be called once by MoC (not by any validator) or contract's owner.

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Refactor)