### PR TITLE
(Feature) Add script for checking contracts' functions for a clashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Solidity smart contracts for PoA validator set consensus",
   "main": "",
   "scripts": {
-    "test": "bash scripts/test.sh",
+    "test": "node scripts/checkForClashing.js && bash scripts/test.sh",
     "coverage": "SOLIDITY_COVERAGE=true bash scripts/test.sh"
   },
-  "author": "Roman Storm & Viktor Baranov",
+  "author": "Roman Storm, Viktor Baranov, Vadim Arasev",
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.1.2",

--- a/scripts/checkForClashing.js
+++ b/scripts/checkForClashing.js
@@ -1,0 +1,92 @@
+// This script checks the functions of contracts for clashing.
+// See https://medium.com/nomic-labs-blog/malicious-backdoors-in-ethereum-proxies-62629adf3357
+// for details.
+
+const fs = require('fs');
+const solc = require('solc');
+
+main();
+
+async function main() {
+	console.log('Checking the contracts\' functions for a clashing...');
+
+	let dir = './contracts/';
+
+	if (!fs.existsSync(dir)) {
+		dir = '.' + dir;
+	}
+
+	const eternalStorageProxyHashes = await getHashes(
+		`${dir}eternal-storage/`,
+		'EternalStorageProxy'
+	);
+
+	const filenames = fs.readdirSync(dir);
+	let contracts = [];
+	let success = true;
+
+	for (let i = 0; i < filenames.length; i++) {
+		const filename = filenames[i];
+		const stats = fs.statSync(dir + filename);
+
+		if (stats.isFile()) {
+			const contractName = filename.replace('.sol', '');
+
+			if (contractName == 'Migrations') {
+				continue;
+			}
+
+			contracts.push(contractName);
+		}
+	}
+
+	for (let i = 0; i < contracts.length; i++) {
+		const contractName = contracts[i];
+		const contractHashes = await getHashes(dir, contractName);
+
+		for (const fnSignature in contractHashes) {
+			const fnHash = contractHashes[fnSignature];
+
+			for (const eternalFnSignature in eternalStorageProxyHashes) {
+				const eternalFnHash = eternalStorageProxyHashes[eternalFnSignature];
+
+				if (fnHash == eternalFnHash) {
+					console.error('');
+					console.error(`Error: the hash for ${contractName}.${fnSignature} is the same as for EternalStorageProxy.${eternalFnSignature}`);
+					success = false;
+				}
+			}
+		}
+	}
+
+	if (success) {
+		console.log('Success');
+		console.log('');
+	} else {
+		console.error('');
+		process.exit(1);
+	}
+}
+
+async function getHashes(dir, contractName) {
+	const compiled = solc.compile({
+		sources: {
+			'': fs.readFileSync(dir + contractName + '.sol').toString()
+		}
+	}, 1, function (path) {
+		let content;
+		try {
+			content = fs.readFileSync(dir + path);
+		} catch (e) {
+			if (e.code == 'ENOENT') {
+				content = fs.readFileSync(dir + '../' + path);
+			}
+		}
+		return {
+			contents: content.toString()
+		}
+	});
+	return compiled.contracts[':' + contractName].functionHashes;
+}
+
+// node checkForClashing.js


### PR DESCRIPTION
- (Mandatory) Description
An introduction of the mechanism of upgradable contracts entails the risk of functions' signatures clashing in Proxy and underlying proxied contract. To exclude that risk the command `npm run test` was complemented with calling of `scripts/checkForClashing.js`. That's the script checking hashes of all functions of each contract for clashing with `EternalStorageProxy` contract's functions. See https://medium.com/nomic-labs-blog/malicious-backdoors-in-ethereum-proxies-62629adf3357 for more details.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Feature)