### PR TITLE
(Fix) A few enhancements in migrations/2_deploy_contract.js

### DIFF
--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -155,9 +155,9 @@ module.exports = function(deployer, network, accounts) {
 
       // Initialize VotingToManageEmissionFunds
       await votingToManageEmissionFunds.init(
-        demoMode ? moment.utc().add(1, 'minutes').unix() : moment.utc().add(3, 'months').unix(),
-        demoMode ? 604800 : 7776000,
-        demoMode ? 86400 : 604800,
+        demoMode ? moment.utc().add(5, 'minutes').unix() : moment.utc().add(3, 'months').unix(),
+        demoMode ? 3600 : 7776000, // emissionReleaseThreshold: 1 hour for demo, 3 months for production
+        demoMode ? 1500 : 604800, // distributionThreshold: 25 minutes for demo, 7 days for production
         emissionFunds.address
       );
 

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -34,11 +34,15 @@ module.exports = function(deployer, network, accounts) {
 
     deployer.then(async function() {
       if (!!process.env.DEPLOY_POA === true) {
-        poaNetworkConsensus = PoaNetworkConsensus.at(poaNetworkConsensusAddress);
-        let validators = await poaNetworkConsensus.getValidators.call();
-        const mocIndex = validators.indexOf(masterOfCeremony.toLowerCase())
-        if (mocIndex > -1) {
-          validators.splice(mocIndex, 1);
+        let validators = [];
+
+        if (poaNetworkConsensusAddress) {
+          poaNetworkConsensus = PoaNetworkConsensus.at(poaNetworkConsensusAddress);
+          validators = await poaNetworkConsensus.getValidators.call();
+          const mocIndex = validators.indexOf(masterOfCeremony.toLowerCase())
+          if (mocIndex > -1) {
+            validators.splice(mocIndex, 1);
+          }
         }
 
         poaNetworkConsensus = await PoaNetworkConsensus.new(masterOfCeremony, validators);

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -155,7 +155,7 @@ module.exports = function(deployer, network, accounts) {
 
       // Initialize VotingToManageEmissionFunds
       await votingToManageEmissionFunds.init(
-        demoMode ? moment.utc().add(5, 'minutes').unix() : moment.utc().add(3, 'months').unix(),
+        demoMode ? moment.utc().add(10, 'minutes').unix() : moment.utc().add(3, 'months').unix(),
         demoMode ? 3600 : 7776000, // emissionReleaseThreshold: 1 hour for demo, 3 months for production
         demoMode ? 1500 : 604800, // distributionThreshold: 25 minutes for demo, 7 days for production
         emissionFunds.address

--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -155,9 +155,9 @@ module.exports = function(deployer, network, accounts) {
 
       // Initialize VotingToManageEmissionFunds
       await votingToManageEmissionFunds.init(
-        moment.utc().add(3, 'months').unix(),
-        7776000,
-        604800,
+        demoMode ? moment.utc().add(1, 'minutes').unix() : moment.utc().add(3, 'months').unix(),
+        demoMode ? 604800 : 7776000,
+        demoMode ? 86400 : 604800,
         emissionFunds.address
       );
 


### PR DESCRIPTION
- (Mandatory) Description
These changes allow deploying `PoaNetworkConsensus` contract with `migrations/2_deploy_contract.js` from scratch and allow using `demoMode` for `VotingToManageEmissionFunds.init` function (the `demoMode` is used in `poa-test-setup`).

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)