### PR TITLE
(Fix) Get rid of limitation in RewardByBlock.addExtraReceiver function

### DIFF
--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -39,11 +39,13 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
         external
         onlyBridgeContract
     {
-        require(_receiver != address(0));
         require(_amount != 0);
-        require(extraReceiversAmounts(_receiver) == 0);
-        _setExtraReceiverAmount(_amount, _receiver);
-        _addExtraReceiver(_receiver);
+        require(_receiver != address(0));
+        uint256 oldAmount = extraReceiversAmounts(_receiver);
+        if (oldAmount == 0) {
+            _addExtraReceiver(_receiver);
+        }
+        _setExtraReceiverAmount(oldAmount.add(_amount), _receiver);
         emit AddedReceiver(_amount, _receiver);
     }
 

--- a/test/reward_by_block_test.js
+++ b/test/reward_by_block_test.js
@@ -243,7 +243,7 @@ contract('RewardByBlock [all features]', function (accounts) {
       ).should.be.rejectedWith(ERROR_MSG);
     });
 
-    it('can only be called once for the same recipient', async () => {
+    it('can be called repeatedly for the same recipient', async () => {
       await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
         1,
@@ -251,10 +251,28 @@ contract('RewardByBlock [all features]', function (accounts) {
         {from: accounts[2]}
       ).should.be.fulfilled;
       await rewardByBlock.addExtraReceiver(
-        1,
+        2,
         accounts[1],
         {from: accounts[2]}
-      ).should.be.rejectedWith(ERROR_MSG);
+      ).should.be.fulfilled;
+      (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(1);
+      (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[1]);
+      (await rewardByBlock.extraReceiversAmounts.call(accounts[1])).should.be.bignumber.equal(3);
+
+      await rewardByBlock.setSystemAddress(systemAddress);
+      const result = await rewardByBlock.reward(
+        [miningKey],
+        [0],
+        {from: systemAddress}
+      ).should.be.fulfilled;
+      result.logs[0].event.should.be.equal('Rewarded');
+      result.logs[0].args.receivers.should.be.deep.equal([payoutKey, emissionFundsAddress, accounts[1]]);
+      result.logs[0].args.rewards[0].toString().should.be.equal(blockRewardAmount.toString());
+      result.logs[0].args.rewards[1].toString().should.be.equal(emissionFundsAmount.toString());
+      result.logs[0].args.rewards[2].toString().should.be.equal('3');
+
+      (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
+      (await rewardByBlock.extraReceiversAmounts.call(accounts[1])).should.be.bignumber.equal(0);
     });
 
     it('should add receivers', async () => {


### PR DESCRIPTION
- (Mandatory) Description
Solves the issue https://github.com/poanetwork/poa-network-consensus-contracts/issues/185. Unit tests were also updated accordingly. The new behavior of `RewardByBlock.addExtraReceiver` function can be tested with https://github.com/varasev/test-block-reward, performing the command `npm run accrue 1 && npm run accrue 1` - as a result, 2 coins will have been accrued within the same block.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)