### PR TITLE
(Feature) Add minting statistics to RewardByBlock contract

### DIFF
--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -147,6 +147,9 @@ module.exports = function(deployer, network, accounts) {
       emissionFunds = await EmissionFunds.new(votingToManageEmissionFunds.address);
 
       // Deploy RewardByBlock
+      // TODO:
+      //   set correct values for public constants
+      //   in RewardByBlock before its deploying
       rewardByBlock = await RewardByBlock.new();
       rewardByBlockImplAddress = rewardByBlock.address;
       rewardByBlock = await EternalStorageProxy.new(

--- a/test/reward_by_block_test.js
+++ b/test/reward_by_block_test.js
@@ -144,6 +144,12 @@ contract('RewardByBlock [all features]', function (accounts) {
     });
 
     it('should assign rewards to payout key and EmissionFunds', async () => {
+      (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedForAccountInBlock.call(payoutKey, web3.eth.blockNumber)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedForAccountInBlock.call(emissionFundsAddress, web3.eth.blockNumber)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedInBlock.call(web3.eth.blockNumber)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotally.call()).should.be.bignumber.equal(0);
       await rewardByBlock.setSystemAddress(systemAddress);
       const {logs} = await rewardByBlock.reward(
         [miningKey],
@@ -154,6 +160,13 @@ contract('RewardByBlock [all features]', function (accounts) {
       logs[0].args.receivers.should.be.deep.equal([payoutKey, emissionFundsAddress]);
       logs[0].args.rewards[0].toString().should.be.equal(blockRewardAmount.toString());
       logs[0].args.rewards[1].toString().should.be.equal(emissionFundsAmount.toString());
+      (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(blockRewardAmount);
+      (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(emissionFundsAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(payoutKey, web3.eth.blockNumber)).should.be.bignumber.equal(blockRewardAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(emissionFundsAddress, web3.eth.blockNumber)).should.be.bignumber.equal(emissionFundsAmount);
+      const totalMinted = web3.toBigNumber(blockRewardAmount).plus(emissionFundsAmount);
+      (await rewardByBlock.mintedInBlock.call(web3.eth.blockNumber)).should.be.bignumber.equal(totalMinted);
+      (await rewardByBlock.mintedTotally.call()).should.be.bignumber.equal(totalMinted);
     });
 
     it('should assign reward to mining key if payout key is 0', async () => {
@@ -215,6 +228,23 @@ contract('RewardByBlock [all features]', function (accounts) {
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversAmounts.call(accounts[3])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
+
+      (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(blockRewardAmount * 2);
+      (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(emissionFundsAmount * 2);
+      (await rewardByBlock.mintedForAccount.call(accounts[2])).should.be.bignumber.equal(4);
+      (await rewardByBlock.mintedForAccount.call(accounts[3])).should.be.bignumber.equal(6);
+      
+      (await rewardByBlock.mintedForAccountInBlock.call(payoutKey, web3.eth.blockNumber)).should.be.bignumber.equal(blockRewardAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(emissionFundsAddress, web3.eth.blockNumber)).should.be.bignumber.equal(emissionFundsAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(accounts[2], web3.eth.blockNumber)).should.be.bignumber.equal(2);
+      (await rewardByBlock.mintedForAccountInBlock.call(accounts[3], web3.eth.blockNumber)).should.be.bignumber.equal(3);
+      
+      (await rewardByBlock.mintedInBlock.call(web3.eth.blockNumber)).should.be.bignumber.equal(
+        web3.toBigNumber(blockRewardAmount).plus(emissionFundsAmount).plus(2).plus(3)
+      );
+      (await rewardByBlock.mintedTotally.call()).should.be.bignumber.equal(
+        web3.toBigNumber(blockRewardAmount).plus(emissionFundsAmount).plus(2).plus(3).mul(2)
+      );
     });
   });
 

--- a/test/reward_by_block_upgrade_test.js
+++ b/test/reward_by_block_upgrade_test.js
@@ -149,6 +149,12 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
     });
 
     it('should assign rewards to payout key and EmissionFunds', async () => {
+      (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedForAccountInBlock.call(payoutKey, web3.eth.blockNumber)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedForAccountInBlock.call(emissionFundsAddress, web3.eth.blockNumber)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedInBlock.call(web3.eth.blockNumber)).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotally.call()).should.be.bignumber.equal(0);
       await rewardByBlock.setSystemAddress(systemAddress);
       const {logs} = await rewardByBlock.reward(
         [miningKey],
@@ -159,6 +165,13 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
       logs[0].args.receivers.should.be.deep.equal([payoutKey, emissionFundsAddress]);
       logs[0].args.rewards[0].toString().should.be.equal(blockRewardAmount.toString());
       logs[0].args.rewards[1].toString().should.be.equal(emissionFundsAmount.toString());
+      (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(blockRewardAmount);
+      (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(emissionFundsAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(payoutKey, web3.eth.blockNumber)).should.be.bignumber.equal(blockRewardAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(emissionFundsAddress, web3.eth.blockNumber)).should.be.bignumber.equal(emissionFundsAmount);
+      const totalMinted = web3.toBigNumber(blockRewardAmount).plus(emissionFundsAmount);
+      (await rewardByBlock.mintedInBlock.call(web3.eth.blockNumber)).should.be.bignumber.equal(totalMinted);
+      (await rewardByBlock.mintedTotally.call()).should.be.bignumber.equal(totalMinted);
     });
 
     it('should assign reward to mining key if payout key is 0', async () => {
@@ -220,6 +233,23 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
       (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversAmounts.call(accounts[3])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
+
+      (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(blockRewardAmount * 2);
+      (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(emissionFundsAmount * 2);
+      (await rewardByBlock.mintedForAccount.call(accounts[2])).should.be.bignumber.equal(4);
+      (await rewardByBlock.mintedForAccount.call(accounts[3])).should.be.bignumber.equal(6);
+      
+      (await rewardByBlock.mintedForAccountInBlock.call(payoutKey, web3.eth.blockNumber)).should.be.bignumber.equal(blockRewardAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(emissionFundsAddress, web3.eth.blockNumber)).should.be.bignumber.equal(emissionFundsAmount);
+      (await rewardByBlock.mintedForAccountInBlock.call(accounts[2], web3.eth.blockNumber)).should.be.bignumber.equal(2);
+      (await rewardByBlock.mintedForAccountInBlock.call(accounts[3], web3.eth.blockNumber)).should.be.bignumber.equal(3);
+      
+      (await rewardByBlock.mintedInBlock.call(web3.eth.blockNumber)).should.be.bignumber.equal(
+        web3.toBigNumber(blockRewardAmount).plus(emissionFundsAmount).plus(2).plus(3)
+      );
+      (await rewardByBlock.mintedTotally.call()).should.be.bignumber.equal(
+        web3.toBigNumber(blockRewardAmount).plus(emissionFundsAmount).plus(2).plus(3).mul(2)
+      );
     });
   });
 


### PR DESCRIPTION
**(Mandatory) Description**

Solves the issue https://github.com/poanetwork/poa-network-consensus-contracts/issues/186. Unit tests were also updated accordingly. These changes add the next public getters for reading minting statistics:
```
mintedForAccount(address _account) public view returns(uint256)
mintedForAccountInBlock(address _account, uint256 _blockNumber) public view returns(uint256)
mintedInBlock(uint256 _blockNumber) public view returns(uint256) public view returns(uint256)
mintedTotally() public view returns(uint256)
```

**(Mandatory) What is it: (Fix), (Feature), or (Refactor)**
(Feature)