### PR TITLE
(Feature) Allow using several bridges and add bridge minting statistics

### DIFF
--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -26,6 +26,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
     uint256 public constant blockRewardAmount = 1 ether; 
     uint256 public constant emissionFundsAmount = 1 ether;
     address public constant emissionFunds = 0x0000000000000000000000000000000000000000;
+    uint256 public constant bridgesAllowedLength = 3;
     // solhint-enable const-name-snakecase
 
     event AddedReceiver(uint256 amount, address indexed receiver, address indexed bridge);
@@ -69,9 +70,9 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
 
         require(_isMiningActive(miningKey));
 
-        uint256 length = extraReceiversLength();
+        uint256 extraLength = extraReceiversLength();
 
-        address[] memory receivers = new address[](length.add(2));
+        address[] memory receivers = new address[](extraLength.add(2));
         uint256[] memory rewards = new uint256[](receivers.length);
 
         receivers[0] = _getPayoutByMining(miningKey);
@@ -81,7 +82,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
 
         uint256 i;
         
-        for (i = 0; i < length; i++) {
+        for (i = 0; i < extraLength; i++) {
             address extraAddress = extraReceiverByIndex(i);
             uint256 extraAmount = extraReceiverAmount(extraAddress);
             _setExtraReceiverAmount(0, extraAddress);
@@ -93,8 +94,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
             _setMinted(rewards[i], receivers[i]);
         }
 
-        length = bridgesAllowed().length;
-        for (i = 0; i < length; i++) {
+        for (i = 0; i < bridgesAllowedLength; i++) {
             address bridgeAddress = bridgesAllowed()[i];
             uint256 bridgeAmountForBlock = bridgeAmount(bridgeAddress);
 
@@ -111,12 +111,12 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
         return (receivers, rewards);
     }
 
-    function bridgesAllowed() public pure returns(address[3]) {
+    function bridgesAllowed() public pure returns(address[bridgesAllowedLength]) {
         // These values must be changed before deploy
         return([
-            0x0000000000000000000000000000000000000000,
-            0x0000000000000000000000000000000000000000,
-            0x0000000000000000000000000000000000000000
+            address(0x0000000000000000000000000000000000000000),
+            address(0x0000000000000000000000000000000000000000),
+            address(0x0000000000000000000000000000000000000000)
         ]);
     }
 
@@ -206,10 +206,10 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
     }
 
     function _isBridgeContract(address _addr) private pure returns(bool) {
-        uint256 length = bridgesAllowed().length;
-
-        for (uint256 i = 0; i < length; i++) {
-            if (_addr == bridgesAllowed()[i]) {
+        address[bridgesAllowedLength] memory bridges = bridgesAllowed();
+        
+        for (uint256 i = 0; i < bridges.length; i++) {
+            if (_addr == bridges[i]) {
                 return true;
             }
         }

--- a/test/mockContracts/RewardByBlockMock.sol
+++ b/test/mockContracts/RewardByBlockMock.sol
@@ -4,18 +4,17 @@ import '../../contracts/RewardByBlock.sol';
 
 
 contract RewardByBlockMock is RewardByBlock {
-    modifier onlyBridgeContract {
-        require(msg.sender == addressStorage[keccak256("bridgeContractAddress")]);
-        _;
-    }
-
     modifier onlySystem {
         require(msg.sender == addressStorage[keccak256("systemAddress")]);
         _;
     }
 
-    function setBridgeContractAddress(address _address) public {
-        addressStorage[keccak256("bridgeContractAddress")] = _address;
+    function bridgesAllowed() public pure returns(address[3]) {
+        return([
+            0x6704Fbfcd5Ef766B287262fA2281C105d57246a6,
+            0x9E1Ef1eC212F5DFfB41d35d9E5c14054F26c6560,
+            0xce42bdB34189a93c55De250E011c68FaeE374Dd3
+        ]);
     }
 
     function setSystemAddress(address _address) public {

--- a/test/reward_by_block_test.js
+++ b/test/reward_by_block_test.js
@@ -190,9 +190,17 @@ contract('RewardByBlock [all features]', function (accounts) {
     });
 
     it('should assign rewards to extra receivers and clear extra receivers list', async () => {
-      await rewardByBlock.setBridgeContractAddress(accounts[1]);
+      (await rewardByBlock.bridgeAmount.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[3])).should.be.bignumber.equal(0);
       await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
       await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
+      (await rewardByBlock.bridgeAmount.call(accounts[1])).should.be.bignumber.equal(5);
+      (await rewardByBlock.bridgeAmount.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[3])).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[3])).should.be.bignumber.equal(0);
 
       await rewardByBlock.setSystemAddress(systemAddress);
       let result = await rewardByBlock.reward(
@@ -207,9 +215,15 @@ contract('RewardByBlock [all features]', function (accounts) {
       result.logs[0].args.rewards[2].toString().should.be.equal('2');
       result.logs[0].args.rewards[3].toString().should.be.equal('3');
 
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(0);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[3])).should.be.bignumber.equal(0);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[3])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[3])).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[1])).should.be.bignumber.equal(5);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[3])).should.be.bignumber.equal(0);
 
       await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
       await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
@@ -225,9 +239,12 @@ contract('RewardByBlock [all features]', function (accounts) {
       result.logs[0].args.rewards[2].toString().should.be.equal('2');
       result.logs[0].args.rewards[3].toString().should.be.equal('3');
 
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(0);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[3])).should.be.bignumber.equal(0);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[3])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[1])).should.be.bignumber.equal(10);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.mintedTotallyByBridge.call(accounts[3])).should.be.bignumber.equal(0);
 
       (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(blockRewardAmount * 2);
       (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(emissionFundsAmount * 2);
@@ -251,12 +268,10 @@ contract('RewardByBlock [all features]', function (accounts) {
   describe('#addExtraReceiver', async () => {
     it('may only be called by bridge contract', async () => {
       await rewardByBlock.addExtraReceiver(1, accounts[1]).should.be.rejectedWith(ERROR_MSG);
-      await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(1, accounts[1], {from: accounts[2]}).should.be.fulfilled;
     });
 
     it('should revert if receiver address is 0x0', async () => {
-      await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
         1,
         '0x0000000000000000000000000000000000000000',
@@ -265,7 +280,6 @@ contract('RewardByBlock [all features]', function (accounts) {
     });
 
     it('should revert if amount is 0', async () => {
-      await rewardByBlock.setBridgeContractAddress(accounts[2]);
       await rewardByBlock.addExtraReceiver(
         0,
         accounts[1],
@@ -274,7 +288,9 @@ contract('RewardByBlock [all features]', function (accounts) {
     });
 
     it('can be called repeatedly for the same recipient', async () => {
-      await rewardByBlock.setBridgeContractAddress(accounts[2]);
+      (await rewardByBlock.bridgeAmount.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[3])).should.be.bignumber.equal(0);
       await rewardByBlock.addExtraReceiver(
         1,
         accounts[1],
@@ -283,11 +299,14 @@ contract('RewardByBlock [all features]', function (accounts) {
       await rewardByBlock.addExtraReceiver(
         2,
         accounts[1],
-        {from: accounts[2]}
+        {from: accounts[3]}
       ).should.be.fulfilled;
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(1);
-      (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[1]);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[1])).should.be.bignumber.equal(3);
+      (await rewardByBlock.extraReceiverByIndex.call(0)).should.be.equal(accounts[1]);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[1])).should.be.bignumber.equal(3);
+      (await rewardByBlock.bridgeAmount.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[2])).should.be.bignumber.equal(1);
+      (await rewardByBlock.bridgeAmount.call(accounts[3])).should.be.bignumber.equal(2);
 
       await rewardByBlock.setSystemAddress(systemAddress);
       const result = await rewardByBlock.reward(
@@ -302,31 +321,35 @@ contract('RewardByBlock [all features]', function (accounts) {
       result.logs[0].args.rewards[2].toString().should.be.equal('3');
 
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[1])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.bridgeAmount.call(accounts[3])).should.be.bignumber.equal(0);
     });
 
     it('should add receivers', async () => {
-      await rewardByBlock.setBridgeContractAddress(accounts[1]);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(0);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[2])).should.be.bignumber.equal(0);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(0);
 
       let result = await rewardByBlock.addExtraReceiver(2, accounts[2], {from: accounts[1]}).should.be.fulfilled;
-      (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[2]);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(2);
+      (await rewardByBlock.extraReceiverByIndex.call(0)).should.be.equal(accounts[2]);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[2])).should.be.bignumber.equal(2);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(1);
       result.logs[0].event.should.be.equal('AddedReceiver');
       result.logs[0].args.receiver.should.be.equal(accounts[2]);
       result.logs[0].args.amount.should.be.bignumber.equal(2);
+      result.logs[0].args.bridge.should.be.equal(accounts[1]);
 
       result = await rewardByBlock.addExtraReceiver(3, accounts[3], {from: accounts[1]}).should.be.fulfilled;
-      (await rewardByBlock.extraReceivers.call(0)).should.be.equal(accounts[2]);
-      (await rewardByBlock.extraReceivers.call(1)).should.be.equal(accounts[3]);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[2])).should.be.bignumber.equal(2);
-      (await rewardByBlock.extraReceiversAmounts.call(accounts[3])).should.be.bignumber.equal(3);
+      (await rewardByBlock.extraReceiverByIndex.call(0)).should.be.equal(accounts[2]);
+      (await rewardByBlock.extraReceiverByIndex.call(1)).should.be.equal(accounts[3]);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[2])).should.be.bignumber.equal(2);
+      (await rewardByBlock.extraReceiverAmount.call(accounts[3])).should.be.bignumber.equal(3);
       (await rewardByBlock.extraReceiversLength.call()).should.be.bignumber.equal(2);
       result.logs[0].event.should.be.equal('AddedReceiver');
       result.logs[0].args.receiver.should.be.equal(accounts[3]);
       result.logs[0].args.amount.should.be.bignumber.equal(3);
+      result.logs[0].args.bridge.should.be.equal(accounts[1]);
     });
   });
 


### PR DESCRIPTION
- (Mandatory) Description
This PR solves the issue https://github.com/poanetwork/poa-network-consensus-contracts/issues/200. Now, `bridgesAllowed` function is used instead of `bridgeContract` constant. The new `mintedTotallyByBridge` function has been added to retrieve the total amount of coins minted by a specified bridge.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Feature)