### PR TITLE
(Fix) Return empty results for zero input address in `RewardByBlock.reward` function

### DIFF
--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -52,7 +52,8 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
         BallotsStorage,
         PoaConsensus,
         ValidatorMetadata,
-        ProxyStorage
+        ProxyStorage,
+        RewardByBlock
     }
 
     event ProxyInitialized(
@@ -210,6 +211,10 @@ contract ProxyStorage is EternalStorage, IProxyStorage {
             ).upgradeTo(_contractAddress);
         } else if (_contractType == uint256(ContractTypes.ProxyStorage)) {
             success = IEternalStorageProxy(this).upgradeTo(_contractAddress);
+        } else if (_contractType == uint256(ContractTypes.RewardByBlock)) {
+            success = IEternalStorageProxy(
+                getRewardByBlock()
+            ).upgradeTo(_contractAddress);
         }
         if (success) {
             emit AddressSet(_contractType, _contractAddress);

--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -69,9 +69,8 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
         address miningKey = benefactors[0];
 
         if (miningKey == address(0)) {
-            address[] memory emptyReceivers = new address[](0);
-            uint256[] memory emptyRewards = new uint256[](0);
-            return (emptyReceivers, emptyRewards);
+        	// Return empty arrays
+            return (new address[](0), new uint256[](0));
         }
 
         require(_isMiningActive(miningKey));

--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -68,6 +68,12 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
 
         address miningKey = benefactors[0];
 
+        if (miningKey == address(0)) {
+            address[] memory emptyReceivers = new address[](0);
+            uint256[] memory emptyRewards = new uint256[](0);
+            return (emptyReceivers, emptyRewards);
+        }
+
         require(_isMiningActive(miningKey));
 
         uint256 extraLength = extraReceiversLength();

--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -69,7 +69,7 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
         address miningKey = benefactors[0];
 
         if (miningKey == address(0)) {
-        	// Return empty arrays
+            // Return empty arrays
             return (new address[](0), new uint256[](0));
         }
 

--- a/test/proxy_storage_test.js
+++ b/test/proxy_storage_test.js
@@ -272,6 +272,20 @@ contract('ProxyStorage [all features]', function (accounts) {
         await proxyStorageEternalStorage.version.call()
       );
     })
+    it('sets rewardByBlock', async () => {
+      const rewardByBlockNew = await RewardByBlock.new();
+      
+      await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
+      await setContractAddress(9, rewardByBlockNew.address, true, {from: accounts[4]});
+      await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
+      
+      const eternalProxyAddress = await proxyStorage.getRewardByBlock.call();
+      const eternalProxy = await EternalStorageProxy.at(eternalProxyAddress);
+
+      rewardByBlockNew.address.should.be.equal(
+        await eternalProxy.implementation.call()
+      )
+    })
   })
   describe('#upgradeTo', async () => {
     it('may only be called by ProxyStorage (itself)', async () => {

--- a/test/proxy_storage_upgrade_test.js
+++ b/test/proxy_storage_upgrade_test.js
@@ -279,6 +279,20 @@ contract('ProxyStorage upgraded [all features]', function (accounts) {
         await proxyStorageEternalStorage.version.call()
       );
     })
+    it('sets rewardByBlock', async () => {
+      const rewardByBlockNew = await RewardByBlock.new();
+      
+      await proxyStorage.setVotingToChangeProxyMock(accounts[4]);
+      await setContractAddress(9, rewardByBlockNew.address, true, {from: accounts[4]});
+      await proxyStorage.setVotingToChangeProxyMock(votingToChangeProxyEternalStorage.address);
+      
+      const eternalProxyAddress = await proxyStorage.getRewardByBlock.call();
+      const eternalProxy = await EternalStorageProxy.at(eternalProxyAddress);
+
+      rewardByBlockNew.address.should.be.equal(
+        await eternalProxy.implementation.call()
+      )
+    })
   })
 })
 

--- a/test/voting_to_change_proxy_test.js
+++ b/test/voting_to_change_proxy_test.js
@@ -473,6 +473,15 @@ contract('VotingToChangeProxyAddress [all features]', function (accounts) {
       await deployAndTest({contractType, newAddress})
       newAddress.should.be.equal(await proxyStorageEternalStorage.implementation.call());
     })
+    it('should change RewardByBlock implementation', async () => {
+      const contractType = 9;
+      const rewardByBlockNew = await RewardByBlock.new();
+      const newAddress = rewardByBlockNew.address;
+      await deployAndTest({contractType, newAddress})
+      const eternalProxyAddress = await proxyStorageMock.getRewardByBlock.call();
+      const eternalProxy = await EternalStorageProxy.at(eternalProxyAddress);
+      newAddress.should.be.equal(await eternalProxy.implementation.call());
+    })
     it('prevents double finalize', async () => {
       let newAddress1 = accounts[4];
       let newAddress2 = accounts[5];

--- a/test/voting_to_change_proxy_upgrade_test.js
+++ b/test/voting_to_change_proxy_upgrade_test.js
@@ -480,6 +480,15 @@ contract('VotingToChangeProxyAddress upgraded [all features]', function (account
       await deployAndTest({contractType, newAddress})
       newAddress.should.be.equal(await proxyStorageEternalStorage.implementation.call());
     })
+    it('should change RewardByBlock implementation', async () => {
+      const contractType = 9;
+      const rewardByBlockNew = await RewardByBlock.new();
+      const newAddress = rewardByBlockNew.address;
+      await deployAndTest({contractType, newAddress})
+      const eternalProxyAddress = await proxyStorageMock.getRewardByBlock.call();
+      const eternalProxy = await EternalStorageProxy.at(eternalProxyAddress);
+      newAddress.should.be.equal(await eternalProxy.implementation.call());
+    })
     it('prevents double finalize', async () => {
       let newAddress1 = accounts[4];
       let newAddress2 = accounts[5];


### PR DESCRIPTION
- (Mandatory) Description
This is an update of two contracts: `RewardByBlock` and `ProxyStorage`. The new implementation of `ProxyStorage` allows updating RewardByBlock's implementation through `voting to change proxy`. The new `RewardByBlock` returns empty arrays in case of zero input address for AuRa in `benefactors` array. This should help in solving the issue https://github.com/paritytech/parity-ethereum/issues/9764

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)