### PR TITLE
(Fix) Remove an excess condition from RewardByBlock

### DIFF
--- a/contracts/RewardByBlock.sol
+++ b/contracts/RewardByBlock.sol
@@ -73,8 +73,6 @@ contract RewardByBlock is EternalStorage, IRewardByBlock {
             return (new address[](0), new uint256[](0));
         }
 
-        require(_isMiningActive(miningKey));
-
         uint256 extraLength = extraReceiversLength();
 
         address[] memory receivers = new address[](extraLength.add(2));

--- a/test/reward_by_block_test.js
+++ b/test/reward_by_block_test.js
@@ -127,22 +127,6 @@ contract('RewardByBlock [all features]', function (accounts) {
       ).should.be.rejectedWith(ERROR_MSG);
     });
 
-    it('should revert if mining key does not exist', async () => {
-      const {logs} = await keysManager.removeMiningKey(miningKey3, {from: votingToChangeKeys});
-      logs[0].event.should.equal("MiningKeyChanged");
-      await rewardByBlock.setSystemAddress(systemAddress);
-      await rewardByBlock.reward(
-        [miningKey3],
-        [0],
-        {from: systemAddress}
-      ).should.be.rejectedWith(ERROR_MSG);
-      await rewardByBlock.reward(
-        [miningKey2],
-        [0],
-        {from: systemAddress}
-      ).should.be.fulfilled;
-    });
-
     it('should assign rewards to payout key and EmissionFunds', async () => {
       (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(0);
       (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(0);

--- a/test/reward_by_block_upgrade_test.js
+++ b/test/reward_by_block_upgrade_test.js
@@ -132,22 +132,6 @@ contract('RewardByBlock upgraded [all features]', function (accounts) {
       ).should.be.rejectedWith(ERROR_MSG);
     });
 
-    it('should revert if mining key does not exist', async () => {
-      const {logs} = await keysManager.removeMiningKey(miningKey3, {from: votingToChangeKeys});
-      logs[0].event.should.equal("MiningKeyChanged");
-      await rewardByBlock.setSystemAddress(systemAddress);
-      await rewardByBlock.reward(
-        [miningKey3],
-        [0],
-        {from: systemAddress}
-      ).should.be.rejectedWith(ERROR_MSG);
-      await rewardByBlock.reward(
-        [miningKey2],
-        [0],
-        {from: systemAddress}
-      ).should.be.fulfilled;
-    });
-
     it('should assign rewards to payout key and EmissionFunds', async () => {
       (await rewardByBlock.mintedForAccount.call(payoutKey)).should.be.bignumber.equal(0);
       (await rewardByBlock.mintedForAccount.call(emissionFundsAddress)).should.be.bignumber.equal(0);


### PR DESCRIPTION
This condition in `RewardByBlock` must be removed as if a ballot for removing a validator is finalized in the block which is produced by the removed validator, the `reward` function will revert which will lead to network stop.